### PR TITLE
Extend MottattMelding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea
 .c9/
 *.sublime-workspace
+.vs/
 
 *.swp
 *.*~

--- a/KS.Fiks.IO.Client/Models/IMottattMelding.cs
+++ b/KS.Fiks.IO.Client/Models/IMottattMelding.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -10,12 +11,14 @@ namespace KS.Fiks.IO.Client.Models
 
         Guid? SvarPaMelding { get; }
 
-        Task<Stream> EncryptedStream { get;  }
+        Task<Stream> EncryptedStream { get; }
 
-        Task<Stream> DecryptedStream { get;  }
+        Task<Stream> DecryptedStream { get; }
 
         Task WriteEncryptedZip(string outPath);
 
         Task WriteDecryptedZip(string outPath);
+
+        Task<IEnumerable<IPayload>> Payloads { get; }
     }
 }


### PR DESCRIPTION
All our use cases for this client reads the decrypted stream and handles each entry individually (typically for uploading the individual files to a storage).

I propose extending the MottattMelding class to contain this functionality and serve the individual payloads of a message so consumers does not have to.