### PR TITLE
Allow RabbitMq IConnectionFactory override

### DIFF
--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -13,6 +13,7 @@ using KS.Fiks.IO.Client.Send;
 using Ks.Fiks.Maskinporten.Client;
 using RabbitMQ.Client.Events;
 using System.Net.Http;
+using RabbitMQ.Client;
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 
@@ -32,8 +33,12 @@ namespace KS.Fiks.IO.Client
 
         private readonly IPublicKeyProvider _publicKeyProvider;
 
-        public FiksIOClient(FiksIOConfiguration configuration, HttpClient httpClient = null, IPublicKeyProvider publicKeyProvider = null)
-            : this(configuration, null, null, null, null, null, httpClient, publicKeyProvider)
+        public FiksIOClient(
+            FiksIOConfiguration configuration,
+            HttpClient httpClient = null,
+            IPublicKeyProvider publicKeyProvider = null,
+            IConnectionFactory connectionFactory = null)
+            : this(configuration, null, null, null, null, null, httpClient, publicKeyProvider, connectionFactory)
         {
         }
 
@@ -45,7 +50,8 @@ namespace KS.Fiks.IO.Client
             IDokumentlagerHandler dokumentlagerHandler = null,
             IAmqpHandler amqpHandler = null,
             HttpClient httpClient = null,
-            IPublicKeyProvider publicKeyProvider = null)
+            IPublicKeyProvider publicKeyProvider = null,
+            IConnectionFactory connectionFactory = null)
         {
             KontoId = configuration.KontoConfiguration.KontoId;
 
@@ -83,7 +89,8 @@ namespace KS.Fiks.IO.Client
                                _dokumentlagerHandler,
                                configuration.AmqpConfiguration,
                                configuration.IntegrasjonConfiguration,
-                               configuration.KontoConfiguration);
+                               configuration.KontoConfiguration,
+                               connectionFactory);
         }
 
         public Guid KontoId { get; }


### PR DESCRIPTION
Override of RabbitMq IConnectionFactory allows to:
-  set specific ConnectionFactory properties like "AutomaticRecoveryEnabled" for auto-reconnect on connection drop
- access the connection itself for monitoring health through "IsOpen" property and events like "ConnectionBlocked" and "ConnectionShutdown"