### PR TITLE
Ny feilmelding for ikke-funnet

### DIFF
--- a/KS.Fiks.IO.Client.Tests/Schemas/FeilmeldingTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Schemas/FeilmeldingTests.cs
@@ -45,7 +45,7 @@ namespace KS.Fiks.IO.Client.Tests.Schemas
             };
             Assert.False(JsonValidates(JsonConvert.SerializeObject(serverFeil), $@"./Schema/{FeilmeldingMeldingTypeV1.Serverfeil}.schema.json"));
         }
-        
+
         [Fact]
         public void TestUgyldigforespørselModelValidateWithSchema_Ok()
         {
@@ -79,6 +79,41 @@ namespace KS.Fiks.IO.Client.Tests.Schemas
                 feilmelding = "testFeilmelding"
             };
             Assert.False(JsonValidates(JsonConvert.SerializeObject(serverFeil), $@"./Schema/{FeilmeldingMeldingTypeV1.Ugyldigforespørsel}.schema.json"));
+        }
+
+        [Fact]
+        public void TestIkkefunnetlModelValidateWithSchema_Ok()
+        {
+            var serverFeil = new Ikkefunnet()
+            {
+                CorrelationId = "testCorrelationId",
+                ErrorId = "testErrorId",
+                Feilmelding = "testFeilmelding"
+            };
+            Assert.True(JsonValidates(JsonConvert.SerializeObject(serverFeil), $@"./Schema/{FeilmeldingMeldingTypeV1.Ikkefunnet}.schema.json"));
+        }
+
+        [Fact]
+        public void TestIkkefunnetModelValidateWithSchema_Wrong_Datatype_Fail()
+        {
+            var serverFeil = new
+            {
+                correlationId = "testCorrelationId",
+                errorId = -2,
+                feilmelding = "testFeilmelding"
+            };
+            Assert.False(JsonValidates(JsonConvert.SerializeObject(serverFeil), $@"./Schema/{FeilmeldingMeldingTypeV1.Ikkefunnet}.schema.json"));
+        }
+
+        [Fact]
+        public void TestIkkefunnetModelValidateWithSchema_Missing_Property_Fail()
+        {
+            var serverFeil = new
+            {
+                correlationId = "testCorrelationId",
+                feilmelding = "testFeilmelding"
+            };
+            Assert.False(JsonValidates(JsonConvert.SerializeObject(serverFeil), $@"./Schema/{FeilmeldingMeldingTypeV1.Ikkefunnet}.schema.json"));
         }
 
         private static bool JsonValidates(string jsonString, string pathToSchema)

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -39,6 +39,11 @@
     </ItemGroup>
     <ItemGroup>
         <None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
+        <Content Include="Schema\no.ks.fiks.kvittering.ikkefunnet.v1.schema.json">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+          <Pack>true</Pack>
+          <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
         <Content Include="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             <Pack>true</Pack>

--- a/KS.Fiks.IO.Client/Models/Feilmelding/FeilmeldingMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Client/Models/Feilmelding/FeilmeldingMeldingTypeV1.cs
@@ -4,6 +4,6 @@ namespace KS.Fiks.IO.Client.Models.Feilmelding
     {
         public const string Ugyldigforespørsel = "no.ks.fiks.kvittering.ugyldigforespoersel.v1";
         public const string Serverfeil = "no.ks.fiks.kvittering.serverfeil.v1";
-        public const string IkkeFunnet = "no.ks.fiks.kvittering.ikkefunnet.v1";
+        public const string Ikkefunnet = "no.ks.fiks.kvittering.ikkefunnet.v1";
     }
 }

--- a/KS.Fiks.IO.Client/Models/Feilmelding/FeilmeldingMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Client/Models/Feilmelding/FeilmeldingMeldingTypeV1.cs
@@ -4,5 +4,6 @@ namespace KS.Fiks.IO.Client.Models.Feilmelding
     {
         public const string Ugyldigforespørsel = "no.ks.fiks.kvittering.ugyldigforespoersel.v1";
         public const string Serverfeil = "no.ks.fiks.kvittering.serverfeil.v1";
+        public const string IkkeFunnet = "no.ks.fiks.kvittering.ikke.funnet.v1";
     }
 }

--- a/KS.Fiks.IO.Client/Models/Feilmelding/FeilmeldingMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Client/Models/Feilmelding/FeilmeldingMeldingTypeV1.cs
@@ -4,6 +4,6 @@ namespace KS.Fiks.IO.Client.Models.Feilmelding
     {
         public const string Ugyldigforespørsel = "no.ks.fiks.kvittering.ugyldigforespoersel.v1";
         public const string Serverfeil = "no.ks.fiks.kvittering.serverfeil.v1";
-        public const string IkkeFunnet = "no.ks.fiks.kvittering.ikke.funnet.v1";
+        public const string IkkeFunnet = "no.ks.fiks.kvittering.ikkefunnet.v1";
     }
 }

--- a/KS.Fiks.IO.Client/Models/Feilmelding/IkkeFunnet.cs
+++ b/KS.Fiks.IO.Client/Models/Feilmelding/IkkeFunnet.cs
@@ -1,0 +1,9 @@
+using System;
+using Newtonsoft.Json;
+
+namespace KS.Fiks.IO.Client.Models.Feilmelding
+{
+    public class IkkeFunnet : FeilmeldingBase
+    {
+    }
+}

--- a/KS.Fiks.IO.Client/Models/Feilmelding/Ikkefunnet.cs
+++ b/KS.Fiks.IO.Client/Models/Feilmelding/Ikkefunnet.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace KS.Fiks.IO.Client.Models.Feilmelding
 {
-    public class IkkeFunnet : FeilmeldingBase
+    public class Ikkefunnet : FeilmeldingBase
     {
     }
 }

--- a/KS.Fiks.IO.Client/Schema/no.ks.fiks.kvittering.ikkefunnet.v1.schema.json
+++ b/KS.Fiks.IO.Client/Schema/no.ks.fiks.kvittering.ikkefunnet.v1.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://no.ks.fiks.kvittering/ikkefunnet.v1.schema.json",
+  "title": "ikkefunnet",
+  "definitions": {
+  },
+  "type": "object",
+  "properties": {
+    "errorId": {
+      "type": "string"
+    },   
+    "feilmelding": {
+      "type": "string"    
+    },
+    "correlationId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "errorId",
+    "feilmelding"
+  ]
+}


### PR DESCRIPTION
Vi diskuterte på forrige møte at dette skulle være en Fiks-Arkiv meldingstype. 
Men jeg vil argumentere for at denne bør være en feilmeldingstype som er tilgjengelig for alle protokoller. 
De andre feilmeldingstypene, ugyldigforespørsel og serverfeil er tilgjengelig for alle og er på json format. Disse skal skilles ut i en egen NuGet pakke som inneholder alt som er felles for alle protokoller. Da er det opp til hver protokoll å bestemme om man bruker disse meldingstypene eller ikke? Det ville være også litt rart å ha en feilmeldingstype som egentlig er så generell som "ikke funnet" på xml format i motsetning til disse og med egen versjonering som følger Fiks-Arkiv? Den er slik jeg ser det helt lik de andre i innhold. 