### PR TITLE
AmqpHandler keepalive 

### DIFF
--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
@@ -30,6 +30,34 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
             config.AmqpConfiguration.Host.Should().Be("io.fiks.ks.no");
+            config.AmqpConfiguration.KeepAlive.Should().BeFalse();
+            config.ApiConfiguration.Host.Should().Be("api.fiks.ks.no");
+        }
+
+        [Fact]
+        public void DefaultConfigurationWithKeepAliveForProd()
+        {
+
+            var integrationId = Guid.NewGuid();
+            var integrationPassord = Guid.NewGuid().ToString();
+            var kontoId = Guid.NewGuid();
+            var privatNokkel = Guid.NewGuid().ToString();
+            var issuer = Guid.NewGuid().ToString();
+            var certificat = new X509Certificate2();
+
+            var config = FiksIOConfiguration.CreateProdConfiguration(
+                integrasjonId: integrationId,
+                integrasjonPassord: integrationPassord,
+                kontoId: kontoId,
+                privatNokkel: privatNokkel,
+                issuer: issuer,
+                certificate: certificat,
+                keepAlive: true);
+
+            config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
+            config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
+            config.AmqpConfiguration.Host.Should().Be("io.fiks.ks.no");
+            config.AmqpConfiguration.KeepAlive.Should().BeTrue();
             config.ApiConfiguration.Host.Should().Be("api.fiks.ks.no");
         }
 
@@ -56,6 +84,35 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
             config.AmqpConfiguration.Host.Should().Be("io.fiks.test.ks.no");
+            config.AmqpConfiguration.KeepAlive.Should().BeFalse();
+            config.ApiConfiguration.Host.Should().Be("api.fiks.test.ks.no");
+        }
+
+        [Fact]
+        public void DefaultConfigurationWithKeepAliveForTest()
+        {
+
+            var integrationId = Guid.NewGuid();
+            var integrationPassord = Guid.NewGuid().ToString();
+            var kontoId = Guid.NewGuid();
+            var privatNokkel = Guid.NewGuid().ToString();
+            var issuer = Guid.NewGuid().ToString();
+            var certificat = new X509Certificate2();
+
+            var config = FiksIOConfiguration.CreateTestConfiguration(
+                integrasjonId: integrationId,
+                integrasjonPassord: integrationPassord,
+                kontoId: kontoId,
+                privatNokkel: privatNokkel,
+                issuer: issuer,
+                certificate: certificat,
+                keepAlive: true
+            );
+
+            config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
+            config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
+            config.AmqpConfiguration.Host.Should().Be("io.fiks.test.ks.no");
+            config.AmqpConfiguration.KeepAlive.Should().BeTrue();
             config.ApiConfiguration.Host.Should().Be("api.fiks.test.ks.no");
         }
     }

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -56,7 +56,11 @@ namespace KS.Fiks.IO.Client.Amqp
             _kontoConfiguration = kontoConfiguration;
             _connectionFactory = connectionFactory ?? new ConnectionFactory();
             _amqpConsumerFactory = consumerFactory ?? new AmqpConsumerFactory(sendHandler, dokumentlagerHandler, _kontoConfiguration);
-            _ensureAmqpConnectionIsOpenTimer = new Timer(async async => await EnsureAmqpConnectionIsOpen(), null, 5 * 60 * 1000, 5 * 60 * 1000);
+            if (amqpConfiguration.KeepAlive)
+            {
+                _ensureAmqpConnectionIsOpenTimer = new Timer(async async => await EnsureAmqpConnectionIsOpen(), null,
+                    5 * 60 * 1000, 5 * 60 * 1000);
+            }
         }
 
         public static async Task<IAmqpHandler> CreateAsync(
@@ -103,7 +107,7 @@ namespace KS.Fiks.IO.Client.Amqp
             {
                 _channel.Dispose();
                 _connection.Dispose();
-                _ensureAmqpConnectionIsOpenTimer.Dispose();
+                _ensureAmqpConnectionIsOpenTimer?.Dispose();
             }
         }
 

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -123,7 +123,7 @@ namespace KS.Fiks.IO.Client.Amqp
             }
         }
 
-        private bool IsOpen()
+        public bool IsOpen()
         {
             return _channel != null && _channel.IsOpen && 
                    _connection != null && _connection.IsOpen;

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -111,13 +111,13 @@ namespace KS.Fiks.IO.Client.Amqp
         {
             try
             {
-                if (!IsConnected())
+                if (!IsOpen())
                 {
                     var oldConnection = _connection;
                     var oldChannel = _channel;
                     await SetupConnectionAndConnect(_integrasjonConfiguration, _amqpConfiguration).ConfigureAwait(false);
-                    oldChannel.Dispose();
-                    oldConnection.Dispose();
+                    oldChannel?.Dispose();
+                    oldConnection?.Dispose();
                 }
             }
             catch (Exception)
@@ -126,9 +126,10 @@ namespace KS.Fiks.IO.Client.Amqp
             }
         }
 
-        private bool IsConnected()
+        private bool IsOpen()
         {
-            return _channel.IsOpen && _connection.IsOpen;
+            return _channel != null && _channel.IsOpen && 
+                   _connection != null && _connection.IsOpen;
         }
 
         internal async Task SetupConnectionAndConnect(IntegrasjonConfiguration integrasjonConfiguration, AmqpConfiguration amqpConfiguration)

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -113,20 +113,13 @@ namespace KS.Fiks.IO.Client.Amqp
 
         private async Task EnsureAmqpConnectionIsOpen()
         {
-            try
+            if (!IsOpen())
             {
-                if (!IsOpen())
-                {
-                    var oldConnection = _connection;
-                    var oldChannel = _channel;
-                    await SetupConnectionAndConnect(_integrasjonConfiguration, _amqpConfiguration).ConfigureAwait(false);
-                    oldChannel?.Dispose();
-                    oldConnection?.Dispose();
-                }
-            }
-            catch (Exception)
-            {
-                // do not throw unhandled exception in Timer Callback 
+                var oldConnection = _connection;
+                var oldChannel = _channel;
+                await SetupConnectionAndConnect(_integrasjonConfiguration, _amqpConfiguration).ConfigureAwait(false);
+                oldChannel?.Dispose();
+                oldConnection?.Dispose();
             }
         }
 

--- a/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
@@ -9,5 +9,7 @@ namespace KS.Fiks.IO.Client.Amqp
         void AddMessageReceivedHandler(
             EventHandler<MottattMeldingArgs> receivedEvent,
             EventHandler<ConsumerEventArgs> cancelledEvent);
+
+        bool IsOpen();
     }
 }

--- a/KS.Fiks.IO.Client/Configuration/AmqpConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/AmqpConfiguration.cs
@@ -5,7 +5,7 @@ namespace KS.Fiks.IO.Client.Configuration
 {
     public class AmqpConfiguration
     {
-        public AmqpConfiguration(string host, int port = 5671, SslOption sslOption = null, string applicationName = "Fiks IO klient (dotnet)", ushort prefetchCount = 10)
+        public AmqpConfiguration(string host, int port = 5671, SslOption sslOption = null, string applicationName = "Fiks IO klient (dotnet)", ushort prefetchCount = 10, bool keepAlive = false)
         {
             Host = host;
             Port = port;
@@ -17,6 +17,7 @@ namespace KS.Fiks.IO.Client.Configuration
             };
             ApplicationName = applicationName;
             PrefetchCount = prefetchCount;
+            KeepAlive = keepAlive;
         }
 
         public string Host { get; }
@@ -29,20 +30,22 @@ namespace KS.Fiks.IO.Client.Configuration
          * Setter et menneskelig-leslig navn på applikasjonen som bruker klient. Er til veldig god hjelp ved debugging.
          */
          public string ApplicationName { get; }
-        
+
         /**
          * Hvor mange meldinger skal buffres i klienten når man lytter på nye meldinger? Tilsvarer AMQP Qos/Prefetch størrelse.
          */
         public ushort PrefetchCount { get; }
-        
-        public static AmqpConfiguration CreateProdConfiguration()
+
+        public bool KeepAlive { get; }
+
+        public static AmqpConfiguration CreateProdConfiguration(bool keepAlive = false)
         {
-            return new AmqpConfiguration("io.fiks.ks.no");
+            return new AmqpConfiguration("io.fiks.ks.no", keepAlive: keepAlive);
         }
 
-        public static AmqpConfiguration CreateTestConfiguration()
+        public static AmqpConfiguration CreateTestConfiguration(bool keepAlive = false)
         {
-            return new AmqpConfiguration("io.fiks.test.ks.no");
+            return new AmqpConfiguration("io.fiks.test.ks.no", keepAlive: keepAlive);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
@@ -53,10 +53,11 @@ namespace KS.Fiks.IO.Client.Configuration
             Guid kontoId,
             string privatNokkel,
             string issuer,
-            X509Certificate2 certificate)
+            X509Certificate2 certificate,
+            bool keepAlive = false)
         {
             return new FiksIOConfiguration(
-                amqpConfiguration: AmqpConfiguration.CreateProdConfiguration(),
+                amqpConfiguration: AmqpConfiguration.CreateProdConfiguration(keepAlive),
                 apiConfiguration: ApiConfiguration.CreateProdConfiguration(),
                 integrasjonConfiguration: new IntegrasjonConfiguration(integrasjonId, integrasjonPassord),
                 kontoConfiguration: new KontoConfiguration(kontoId, privatNokkel),
@@ -69,10 +70,11 @@ namespace KS.Fiks.IO.Client.Configuration
             Guid kontoId,
             string privatNokkel,
             string issuer,
-            X509Certificate2 certificate)
+            X509Certificate2 certificate,
+            bool keepAlive = false)
         {
             return new FiksIOConfiguration(
-                amqpConfiguration: AmqpConfiguration.CreateTestConfiguration(),
+                amqpConfiguration: AmqpConfiguration.CreateTestConfiguration(keepAlive),
                 apiConfiguration: ApiConfiguration.CreateTestConfiguration(),
                 integrasjonConfiguration: new IntegrasjonConfiguration(integrasjonId, integrasjonPassord),
                 kontoConfiguration: new KontoConfiguration(kontoId, privatNokkel),

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -171,6 +171,11 @@ namespace KS.Fiks.IO.Client
             _amqpHandler.AddMessageReceivedHandler(onMottattMelding, onCanceled);
         }
 
+        public bool IsOpen()
+        {
+            return _amqpHandler.IsOpen();
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/KS.Fiks.IO.Client/IFiksIOClient.cs
+++ b/KS.Fiks.IO.Client/IFiksIOClient.cs
@@ -26,5 +26,7 @@ namespace KS.Fiks.IO.Client
         void NewSubscription(EventHandler<MottattMeldingArgs> onMottattMelding);
 
         void NewSubscription(EventHandler<MottattMeldingArgs> onMottattMelding, EventHandler<ConsumerEventArgs> onCanceled);
+
+        bool IsOpen();
     }
 }

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -1,54 +1,54 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Title>KS FIKS IO Client</Title>
-        <Authors>Ks-Kommunesektorens Organisasjon</Authors>
-        <Copyright>Ks-Kommunesektorens Organisasjon</Copyright>
-        <RootNamespace>KS.Fiks.IO.Client</RootNamespace>
-        <PackageProjectUrl>https://github.com/ks-no/fiks-io-client-dotnet</PackageProjectUrl>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <PackageIcon>KS.png</PackageIcon>
-        <RepositoryUrl>https://github.com/ks-no/fiks-io-client-dotnet.git</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <PackageTags>FIKS</PackageTags>
-        <VersionPrefix>2.0.1</VersionPrefix>
-        <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <FileVersion>2.0.0.0</FileVersion>
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../fiks-io-strongly-named-key.snk</AssemblyOriginatorKeyFile>
-    </PropertyGroup>
+	<PropertyGroup>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Title>KS FIKS IO Client</Title>
+		<Authors>Ks-Kommunesektorens Organisasjon</Authors>
+		<Copyright>Ks-Kommunesektorens Organisasjon</Copyright>
+		<RootNamespace>KS.Fiks.IO.Client</RootNamespace>
+		<PackageProjectUrl>https://github.com/ks-no/fiks-io-client-dotnet</PackageProjectUrl>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageIcon>KS.png</PackageIcon>
+		<RepositoryUrl>https://github.com/ks-no/fiks-io-client-dotnet.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>FIKS</PackageTags>
+		<VersionPrefix>2.0.1</VersionPrefix>
+		<TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<FileVersion>2.0.0.0</FileVersion>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>../fiks-io-strongly-named-key.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <None Include="KS.png">
-            <Pack>true</Pack>
-            <PackagePath>/</PackagePath>
-        </None>
-        <None Include="../LICENSE">
-            <Pack>true</Pack>
-            <PackagePath>/</PackagePath>
-        </None>
-        <None Include="../README.md">
-            <Pack>true</Pack>
-            <PackagePath>/</PackagePath>
-        </None>
-    </ItemGroup>
+	<ItemGroup>
+		<None Include="KS.png">
+			<Pack>true</Pack>
+			<PackagePath>/</PackagePath>
+		</None>
+		<None Include="../LICENSE">
+			<Pack>true</Pack>
+			<PackagePath>/</PackagePath>
+		</None>
+		<None Include="../README.md">
+			<Pack>true</Pack>
+			<PackagePath>/</PackagePath>
+		</None>
+	</ItemGroup>
 	<ItemGroup>
 		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
 	</ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-        <PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />
-        <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
-        <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.2" />
-        <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="[11.0.1, 13.0.1]" />
-        <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    </ItemGroup>
-  
+	<ItemGroup>
+		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
+		<PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />
+		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
+		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.2" />
+		<PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="[11.0.1, 13.0.1]" />
+		<PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	</ItemGroup>
+
 </Project>

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -37,6 +37,9 @@
             <PackagePath>/</PackagePath>
         </None>
     </ItemGroup>
+	<ItemGroup>
+		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
+	</ItemGroup>
     <ItemGroup>
         <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
         <PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -38,9 +38,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
-    </ItemGroup>
-    <ItemGroup>
         <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
         <PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />
         <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
@@ -50,5 +47,5 @@
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
-    
+  
 </Project>

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ var apiConfig = new ApiConfiguration(
 // Optional: Use custom amqp host (i.e. for connection to test queue)
 var amqp = new AmqpConfiguration(
                 host: "io.fiks.test.ks.no",
-                port: 5671);
+                port: 5671,
+                keepAlive: true);
 
 // Combine all configurations
 var configuration = new FiksIOConfiguration(kontoConfig, integrationConfig, maskinportenConfig, apiConfig, amqpConfig);

--- a/README.md
+++ b/README.md
@@ -101,11 +101,16 @@ var request = new LookupRequest(
 var receiverKontoId = await client.Lookup(request); 
 ```
 
+### IsOpen
+This method can be used to check if the amqp connection is open. 
+
 ### Configuration
 
 Two convenience functions are provided for generating default configurations for *prod* and *test*,
 `CreateMaskinportenProdConfig` and `CreateMaskinportenTestConfig`. Only the required configuration parameters must be provided,
 the rest will be set to default values for the given environment. 
+
+**keepAlive**: Optional setting. Set the `keepAlive` to true if you want the client to check every 5 minutes if the amqp connection is open and automatically reconnect
 
 **privatNokkel**: The `privatNokkel` property expects a private key in PKCS#8 format. Private key which has a PKCS#1 will cause an exception. A PKCS#1 key can be converted using this command: 
 ```powershell
@@ -127,7 +132,8 @@ var config = FiksIOConfiguration.CreateProdConfiguration(
     kontoId: kontoId,
     privatNokkel: privatNokkel,
     issuer: issuer, //klientid for maskinporten
-    certificate: certificat
+    certificate: certificat,
+    keepAlive: false // Optional: use this if you want to use the keepAlive functionality. Default = false
 );
 
 // Test config
@@ -137,7 +143,8 @@ var config = FiksIOConfiguration.CreateTestConfiguration(
     kontoId: kontoId,
     privatNokkel: privatNokkel, 
     issuer: issuer, //klientid for maskinporten
-    certificate: certificat
+    certificate: certificat,
+    keepAlive: false // Optional: use this if you want to use the keepAlive functionality. Default = false
 );
 ```
 
@@ -169,11 +176,13 @@ var apiConfig = new ApiConfiguration(
                 host: "api.fiks.test.ks.no",
                 port: 443);
 
-// Optional: Use custom amqp host (i.e. for connection to test queue)
+// Optional: Use custom amqp host (i.e. for connection to test queue). 
+// Optional: Set keepAlive: true if you want the FiksIOClient to check if amqp connection is open every 5 minutes and automatically reconnect. 
+// another option to using keepAlive is to use the isOpen() method on the FiksIOClient and implement a keepalive strategy yourself 
 var amqp = new AmqpConfiguration(
                 host: "io.fiks.test.ks.no",
                 port: 5671,
-                keepAlive: true);
+                keepAlive: false); 
 
 // Combine all configurations
 var configuration = new FiksIOConfiguration(kontoConfig, integrationConfig, maskinportenConfig, apiConfig, amqpConfig);


### PR DESCRIPTION
AmqpHandler keepalive via configuration

This is a branch derived from this[ pull-request from Jonnybee](https://github.com/ks-no/fiks-io-client-dotnet/pull/106) (thank you for the contribution!). We wanted to have this feature not as a default behaviour.
Also we are exposing the isOpen() method as part of the FiksIOClient.