### PR TITLE
Setter resendt ut i fra redelivered property

### DIFF
--- a/KS.Fiks.IO.Client.Tests/Models/MottattMeldingTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Models/MottattMeldingTests.cs
@@ -42,5 +42,30 @@ namespace KS.Fiks.IO.Client.Tests.Models
 
             mottattMelding.KlientMeldingId.Should().BeNull();
         }
+
+        [Fact]
+        public void TestResendtIsDefaultFalse()
+        {
+            var klientMeldingId = Guid.NewGuid();
+            var headere = new Dictionary<string, string>() {{ MeldingBase.headerKlientMeldingId, klientMeldingId.ToString() }};
+            var mottattMelding = new MottattMelding(false,
+                new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+                    TimeSpan.Zero, headere), null, null, null);
+
+            mottattMelding.Resendt.Should().BeFalse();
+        }
+
+        [Fact]
+        public void TestResendtIsTrueWhenSetToTrue()
+        {
+            var resendt = true;
+            var klientMeldingId = Guid.NewGuid();
+            var headere = new Dictionary<string, string>() {{ MeldingBase.headerKlientMeldingId, klientMeldingId.ToString() }};
+            var mottattMelding = new MottattMelding(false,
+                new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+                    TimeSpan.Zero, headere, resendt), null, null, null);
+
+            mottattMelding.Resendt.Should().BeTrue();
+        }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
@@ -62,7 +62,7 @@ namespace KS.Fiks.IO.Client.Amqp
 
             try
             {
-                var receivedMessage = ParseMessage(properties, body);
+                var receivedMessage = ParseMessage(properties, body, redelivered);
 
                 Received?.Invoke(
                     this,
@@ -106,9 +106,9 @@ namespace KS.Fiks.IO.Client.Amqp
             return IsDataInDokumentlager(properties) || body.Length > 0;
         }
 
-        private MottattMelding ParseMessage(IBasicProperties properties, ReadOnlyMemory<byte> body)
+        private MottattMelding ParseMessage(IBasicProperties properties, ReadOnlyMemory<byte> body, bool resendt)
         {
-            var metadata = ReceivedMessageParser.Parse(this.accountId, properties);
+            var metadata = ReceivedMessageParser.Parse(this.accountId, properties, resendt);
             return new MottattMelding(
                 HasPayload(properties, body),
                 metadata,

--- a/KS.Fiks.IO.Client/Models/MottattMeldingMetadata.cs
+++ b/KS.Fiks.IO.Client/Models/MottattMeldingMetadata.cs
@@ -5,7 +5,7 @@ namespace KS.Fiks.IO.Client.Models
 {
     public class MottattMeldingMetadata : MeldingBase
     {
-        public MottattMeldingMetadata(Guid meldingId, string meldingType, Guid mottakerKontoId, Guid avsenderKontoId, Guid? svarPaMelding, TimeSpan ttl, Dictionary<string, string> headere)
+        public MottattMeldingMetadata(Guid meldingId, string meldingType, Guid mottakerKontoId, Guid avsenderKontoId, Guid? svarPaMelding, TimeSpan ttl, Dictionary<string, string> headere, bool resendt = false)
         {
             MeldingId = meldingId;
             MeldingType = meldingType;
@@ -14,6 +14,7 @@ namespace KS.Fiks.IO.Client.Models
             SvarPaMelding = svarPaMelding;
             Ttl = ttl;
             Headere = headere;
+            Resendt = resendt;
         }
 
         public MottattMeldingMetadata(MottattMeldingMetadata metadata)

--- a/KS.Fiks.IO.Client/Utility/ReceivedMessageParser.cs
+++ b/KS.Fiks.IO.Client/Utility/ReceivedMessageParser.cs
@@ -24,7 +24,8 @@ namespace KS.Fiks.IO.Client.Utility
 
         internal static MottattMeldingMetadata Parse(
             Guid receiverAccountId,
-            IBasicProperties properties)
+            IBasicProperties properties,
+            bool resendt)
         {
             var headers = properties?.Headers;
 
@@ -40,7 +41,8 @@ namespace KS.Fiks.IO.Client.Utility
                 avsenderKontoId: RequireGuidFromHeader(headers, SenderAccountIdHeaderName),
                 svarPaMelding: GetGuidFromHeader(headers, RelatedMessageIdHeaderName),
                 ttl: ParseTimeSpan(properties.Expiration),
-                headere: ExtractEgendefinerteHeadere(headers));
+                headere: ExtractEgendefinerteHeadere(headers),
+                resendt);
         }
 
         internal static Guid RequireGuidFromHeader(IDictionary<string, object> header, string headerName)


### PR DESCRIPTION
Setter resendt på MottattMelding ut i fra redelivered property som var tilgjengelig

Dette er en fiks for issue #52. Det ser ut til at dette bare har vært glemt og ikke implementert. Sjekket java-klienten som brukte `redelivered` property for å sette `resendt` property på MottattMelding.