### PR TITLE
Tatt bort mellomsteg med array

### DIFF
--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -48,7 +48,6 @@ namespace KS.Fiks.IO.Client.Asic
 
         private Stream CreateZipStream(IEnumerable<IPayload> payloads)
         {
-            byte[] zippedBytes;
             using (var zipStream = new MemoryStream())
             {
                 using (var asiceBuilder = _asiceBuilderFactory.GetBuilder(zipStream, MessageDigestAlgorithm.SHA256))
@@ -60,11 +59,8 @@ namespace KS.Fiks.IO.Client.Asic
                         asiceBuilder.Build();
                     }
                 }
-
-                zippedBytes = zipStream.ToArray();
+                return zipStream;
             }
-
-            return new MemoryStream(zippedBytes);
         }
 
         private Stream EncryptStream(Stream zipStream, X509Certificate certificate)


### PR DESCRIPTION
Tatt bort mellomsteg med kopiering til array i CreateZipStream

Forhåpentligvis forbedret litt minnebruken i FiksIOClient. Dette er første steg på å forbedre klienten. 
Vi jobber videre med å ta bort bruk av MemoryStream som spiser minne ved utsendelser.

