### PR TITLE
Midlertidig tilbake til utgangspunktet

### DIFF
--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -85,9 +85,11 @@ namespace KS.Fiks.IO.Client.Asic
                         asiceBuilder.Build();
                     }
                 }
+                //TODO This is hopefully an unnecessary copy to a new stream here? Cannot use zipstream since asiceBuilder needs to get disposed in order to create a manifest and then seems to close the stream too
+                var extraStream = new MemoryStream(zipStream.ToArray());
                 var encryptionService = _encryptionServiceFactory.Create(certificate);
-                zipStream.Seek(0, SeekOrigin.Begin);
-                encryptionService.Encrypt(zipStream, outStream);
+                
+                encryptionService.Encrypt(extraStream, outStream);
             }
             catch (Exception e)
             {

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -84,6 +84,7 @@ namespace KS.Fiks.IO.Client.Asic
                     asiceBuilder.Build();
                 }
                 var encryptionService = _encryptionServiceFactory.Create(certificate);
+                zipStream.Seek(0, SeekOrigin.Begin);
                 encryptionService.Encrypt(zipStream, outStream);
             }
             catch (Exception e)

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -76,7 +76,7 @@ namespace KS.Fiks.IO.Client.Asic
 
             try
             {
-                using var asiceBuilder = _asiceBuilderFactory.GetBuilder(zipStream, MessageDigestAlgorithm.SHA256) 
+                using(var asiceBuilder = _asiceBuilderFactory.GetBuilder(zipStream, MessageDigestAlgorithm.SHA256)) 
                 {
                     foreach (var payload in payloads)
                     {

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -84,17 +84,24 @@ namespace KS.Fiks.IO.Client.Asic
             }
             catch (Exception e)
             {
+                zipStream.Dispose();
                 throw e;
             }
             finally
             {
-                zipStream.Dispose();
                 asiceBuilder.Dispose();
             }
 
             var outStream = new MemoryStream();
-            var encryptionService = _encryptionServiceFactory.Create(certificate);
-            encryptionService.Encrypt(zipStream, outStream);
+            try
+            {
+                var encryptionService = _encryptionServiceFactory.Create(certificate);
+                encryptionService.Encrypt(zipStream, outStream);
+            }
+            finally
+            {
+                zipStream.Dispose();
+            }
 
             return outStream;
         }

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -80,9 +80,10 @@ namespace KS.Fiks.IO.Client.Asic
                     asiceBuilder.AddFile(payload.Payload, payload.Filename);
                     asiceBuilder.Build();
                 }
-                var encryptionService = _encryptionServiceFactory.Create(certificate);
-                encryptionService.Encrypt(zipStream, outStream);
             }
+
+            var encryptionService = _encryptionServiceFactory.Create(certificate);
+            encryptionService.Encrypt(zipStream, outStream);
             return outStream;
         }
     }

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -84,9 +84,12 @@ namespace KS.Fiks.IO.Client.Asic
             }
             catch (Exception e)
             {
+                throw e;
+            }
+            finally
+            {
                 zipStream.Dispose();
                 asiceBuilder.Dispose();
-                throw e;
             }
 
             var outStream = new MemoryStream();

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -74,14 +74,16 @@ namespace KS.Fiks.IO.Client.Asic
             var zipStream = new MemoryStream();
             var outStream = new MemoryStream();
 
-            var asiceBuilder = _asiceBuilderFactory.GetBuilder(zipStream, MessageDigestAlgorithm.SHA256);
             try
             {
-                foreach (var payload in payloads)
+                using var asiceBuilder = _asiceBuilderFactory.GetBuilder(zipStream, MessageDigestAlgorithm.SHA256) 
                 {
-                    payload.Payload.Seek(0, SeekOrigin.Begin);
-                    asiceBuilder.AddFile(payload.Payload, payload.Filename);
-                    asiceBuilder.Build();
+                    foreach (var payload in payloads)
+                    {
+                        payload.Payload.Seek(0, SeekOrigin.Begin);
+                        asiceBuilder.AddFile(payload.Payload, payload.Filename);
+                        asiceBuilder.Build();
+                    }
                 }
                 var encryptionService = _encryptionServiceFactory.Create(certificate);
                 zipStream.Seek(0, SeekOrigin.Begin);
@@ -93,10 +95,7 @@ namespace KS.Fiks.IO.Client.Asic
                 outStream.Dispose();
                 throw e;
             }
-            finally
-            {
-                asiceBuilder.Dispose();
-            }
+
             return outStream;
         }
     }


### PR DESCRIPTION
Må tilbake til å kopiere til ny memorystream

Det ser ut til at vi må midlertidig gjøre det som i utgangspunktet, ved å kopiere til ny memorystream.
Man får ikke en ferdig zip fra AsiceBuilder før den blir disposet. Da lages manifestet. Men da ser streamen ut til å være closed også. 
Dette må vi se om vi kan fikse før vi kan fikse problemet med streaming i fiks-io-klienten. 