### PR TITLE
Oppdatert til ny versjon av asice pakken som ikke stenger stream ved zipping av asice pakken

### DIFF
--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4-build.20221103075620062" />
+        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4" />
         <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.2" />
         <PackageReference Include="Moq" Version="4.18.2" />

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
+        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4-build.20221103075620062" />
         <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.2" />
         <PackageReference Include="Moq" Version="4.18.2" />

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -43,11 +43,6 @@ namespace KS.Fiks.IO.Client.Asic
 
         private Stream ZipAndEncrypt(X509Certificate certificate, IEnumerable<IPayload> payloads)
         {
-            // var zipStream = new MemoryStream();
-            // var outStream = new MemoryStream();
-            //
-            // try
-            // {
             var outStream = new MemoryStream();
             var encryptionService = _encryptionServiceFactory.Create(certificate);
             using (var zipStream = new MemoryStream())
@@ -61,19 +56,10 @@ namespace KS.Fiks.IO.Client.Asic
                         asiceBuilder.Build();
                     }
                 }
+
                 zipStream.Seek(0, SeekOrigin.Begin);
                 encryptionService.Encrypt(zipStream, outStream);
             }
-            //TODO This is hopefully an unnecessary copy to a new stream here? Cannot use zipstream since asiceBuilder needs to get disposed in order to create a manifest and then seems to close the stream too
-            //var extraStream = new MemoryStream(zipStream.ToArray());
-            //encryptionService.Encrypt(extraStream, outStream);
-            // }
-            // catch (Exception e)
-            // {
-            //     // zipStream.Dispose();
-            //     outStream.Dispose();
-            //     throw e;
-            // }
 
             return outStream;
         }

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -60,9 +60,9 @@ namespace KS.Fiks.IO.Client.Asic
                         asiceBuilder.AddFile(payload.Payload, payload.Filename);
                         asiceBuilder.Build();
                     }
-                    zipStream.Seek(0, SeekOrigin.Begin);
-                    encryptionService.Encrypt(zipStream, outStream);
                 }
+                zipStream.Seek(0, SeekOrigin.Begin);
+                encryptionService.Encrypt(zipStream, outStream);
             }
             //TODO This is hopefully an unnecessary copy to a new stream here? Cannot use zipstream since asiceBuilder needs to get disposed in order to create a manifest and then seems to close the stream too
             //var extraStream = new MemoryStream(zipStream.ToArray());

--- a/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicEncrypter.cs
@@ -60,7 +60,7 @@ namespace KS.Fiks.IO.Client.Asic
                         asiceBuilder.AddFile(payload.Payload, payload.Filename);
                         asiceBuilder.Build();
                     }
-
+                    zipStream.Seek(0, SeekOrigin.Begin);
                     encryptionService.Encrypt(zipStream, outStream);
                 }
             }

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -41,7 +41,7 @@
 		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
+		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4-build.20221103075620062" />
 		<PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.2" />

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -41,7 +41,7 @@
 		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4-build.20221103075620062" />
+		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4" />
 		<PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.2" />


### PR DESCRIPTION
Tester ut ny versjon av asice pakken hvor zipStream ikke blir closed

Da skal vi slippe å kopiere til byte array for å opprette ny memorystream.
Sees i sammenheng med denne PR: https://github.com/ks-no/fiks-asice-dotnet/pull/101