### PR TITLE
Fiks for problem med message.DecrypteStream

### DIFF
--- a/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
@@ -112,12 +112,12 @@ namespace KS.Fiks.IO.Client.Amqp
             return new MottattMelding(
                 HasPayload(properties, body),
                 metadata,
-                GetDataProvider(properties, body),
+                GetDataProvider(properties, body.ToArray()),
                 this.decrypter,
                 this.fileWriter);
         }
 
-        private Func<Task<Stream>> GetDataProvider(IBasicProperties properties, ReadOnlyMemory<byte> body)
+        private Func<Task<Stream>> GetDataProvider(IBasicProperties properties, byte[] body)
         {
             if (!HasPayload(properties, body))
             {
@@ -129,7 +129,7 @@ namespace KS.Fiks.IO.Client.Amqp
                 return async () => await this.dokumentlagerHandler.Download(GetDokumentlagerId(properties));
             }
 
-            return async () => await Task.FromResult(new MemoryStream(body.ToArray()));
+            return async () => await Task.FromResult(new MemoryStream(body));
         }
     }
 }


### PR DESCRIPTION
Fiks for problem med message.DecryptedStream

Det ble oppdaget hos Norkart at klienten feilet ved dekryptering når man mottar flere meldinger etter hverandre.
Endringene her er i samsvar med observasjoner og endringer gjort hos Norkart. Når de implementerte disse endringene hos seg sluttet problemet. Vi har foreløpig ikke klart å gjenskape feilen i våre integrasjonstester og prøver først å få problemet bekreftet via tester før vi releaser dette.

Feil fra logger (Norkart):

> 
> KS.Fiks.IO.Client.Exceptions.FiksIODecryptionException: Unable to decrypt melding. Is your private key correct?                                                                                                                                                                                                               ---> Org.BouncyCastle.Cms.CmsException: IOException reading content.                                                                                                                                                                                                                                                         ---> System.IO.IOException: unknown tag 0 encountered                                                                                                                                                                                                                                                                          at Org.BouncyCastle.Asn1.Asn1InputStream.CreatePrimitiveDerObject(Int32 tagNo, DefiniteLengthInputStream defIn, Byte[][] tmpBuffers) in /_/crypto/src/asn1/Asn1InputStream.cs:line 428                                                                                                                                       at Org.BouncyCastle.Asn1.Asn1StreamParser.ReadObject() in /_/crypto/src/asn1/ASN1StreamParser.cs:line 208                                                                                                                                                                                                                    at Org.BouncyCastle.Cms.CmsContentInfoParser..ctor(Stream data) in /_/crypto/src/cms/CMSContentInfoParser.cs:line 27                                                                                                                                                                                                         --- End of inner exception stack trace ---                                                                                                                                                                                                                                                                                   at Org.BouncyCastle.Cms.CmsContentInfoParser..ctor(Stream data) in /_/crypto/src/cms/CMSContentInfoParser.cs:line 31                                                                                                                                                                                                         at Org.BouncyCastle.Cms.CmsEnvelopedDataParser..ctor(Stream envelopedData) in /_/crypto/src/cms/CMSEnvelopedDataParser.cs:line 63                                                                                                                                                                                            at KS.Fiks.Crypto.BouncyCastle.DecryptStreamConverter.Decrypt(AsymmetricKeyParameter privateKey, Stream encryptedStream)                                                                                                                                                                                                     at KS.Fiks.Crypto.DecryptionService.Decrypt(Stream encryptedStream)                                                                                                                                                                                                                                                          at KS.Fiks.IO.Client.Asic.AsicDecrypter.Decrypt(Task`1 encryptedZipStream)   
>  

Og:

> KS.Fiks.IO.Client.Exceptions.FiksIODecryptionException: Unable to decrypt melding. Is your private key correct?                                                                                                                                                                                                               ---> Org.BouncyCastle.Cms.CmsException: Unexpected object reading content.                                                                                                                                                                                                                                                   ---> System.InvalidCastException: Unable to cast object of type 'Org.BouncyCastle.Asn1.DerUtcTime' to type 'Org.BouncyCastle.Asn1.Asn1SequenceParser'.                                                                                                                                                                         at Org.BouncyCastle.Cms.CmsContentInfoParser..ctor(Stream data) in /_/crypto/src/cms/CMSContentInfoParser.cs:line 27                                                                                                                                                                                                         --- End of inner exception stack trace ---                                                                                                                                                                                                                                                                                   at Org.BouncyCastle.Cms.CmsContentInfoParser..ctor(Stream data) in /_/crypto/src/cms/CMSContentInfoParser.cs:line 35                                                                                                                                                                                                         at Org.BouncyCastle.Cms.CmsEnvelopedDataParser..ctor(Stream envelopedData) in /_/crypto/src/cms/CMSEnvelopedDataParser.cs:line 63                                                                                                                                                                                            at KS.Fiks.Crypto.BouncyCastle.DecryptStreamConverter.Decrypt(AsymmetricKeyParameter privateKey, Stream encryptedStream)                                                                                                                                                                                                     at KS.Fiks.IO.Client.Asic.AsicDecrypter.Decrypt(Task`1 encryptedZipStream)       

---- 
UPDATE: Vi har nå klart å gjenskape feilen og laget integrasjonstester som bekrefter det