### PR TITLE
Asice configuration er nå påkrevd

### DIFF
--- a/ExampleApplication/Program.cs
+++ b/ExampleApplication/Program.cs
@@ -91,6 +91,8 @@ namespace ExampleApplication
                 Guid.Parse(integrasjonId) /* Integration id as Guid */,
                 integrasjonPassword /* Integration password */);
 
+            var asiceSigningConfig = new AsiceSigningConfiguration(new X509Certificate2(p12Filename, p12Password));
+
 
             // Optional: Use custom api host (i.e. for connecting to test api)
             var apiConfig = new ApiConfiguration(
@@ -104,8 +106,7 @@ namespace ExampleApplication
                 port: 5671);
 
             // Combine all configurations
-            var configuration = new FiksIOConfiguration(kontoConfig, integrasjonConfig, maskinportenConfig, apiConfig,
-                amqpConfig);
+            var configuration = new FiksIOConfiguration(kontoConfig, integrasjonConfig, maskinportenConfig, asiceSigningConfig, apiConfig, amqpConfig);
         }
 
         private static string ReadFromFile(string path)

--- a/KS.Fiks.IO.Client.Tests/Catalog/CatalogHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Catalog/CatalogHandlerFixture.cs
@@ -206,6 +206,7 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
                 accountConfiguration,
                 new IntegrasjonConfiguration(_integrasjonId, _integrasjonPassword),
                 new MaskinportenClientConfiguration("audience", "token", "issuer", 1, new X509Certificate2()),
+                new AsiceSigningConfiguration(new X509Certificate2()),
                 apiConfiguration: apiConfiguration,
                 katalogConfiguration: catalogConfiguration);
         }

--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
@@ -18,6 +18,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
             var maskinportenSertifikat = new X509Certificate2();
+            var asiceSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateProdConfiguration(
                 integrasjonId: integrationId,
@@ -26,7 +27,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 privatNokkel: privatNokkel,
                 issuer: issuer,
                 maskinportenSertifikat: maskinportenSertifikat,
-                asiceSertifikat: maskinportenSertifikat);
+                asiceSertifikat: asiceSertifikat);
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
@@ -45,6 +46,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
             var maskinportenSertifikat = new X509Certificate2();
+            var asiceSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateProdConfiguration(
                 integrasjonId: integrationId,
@@ -53,7 +55,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 privatNokkel: privatNokkel,
                 issuer: issuer,
                 maskinportenSertifikat: maskinportenSertifikat,
-                asiceSertifikat: maskinportenSertifikat,
+                asiceSertifikat: asiceSertifikat,
                 keepAlive: true);
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
@@ -73,6 +75,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
             var maskinportenSertifikat = new X509Certificate2();
+            var asiceSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateTestConfiguration(
                 fiksIntegrasjonId: integrationId,
@@ -81,7 +84,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 privatNokkel: privatNokkel,
                 issuer: issuer,
                 maskinportenSertifikat: maskinportenSertifikat,
-                asiceSertifikat: maskinportenSertifikat
+                asiceSertifikat: asiceSertifikat
             );
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
@@ -101,6 +104,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
             var maskinportenSertifikat = new X509Certificate2();
+            var asiceSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateTestConfiguration(
                 fiksIntegrasjonId: integrationId,
@@ -109,7 +113,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 privatNokkel: privatNokkel,
                 issuer: issuer,
                 maskinportenSertifikat: maskinportenSertifikat,
-                asiceSertifikat: maskinportenSertifikat,
+                asiceSertifikat: asiceSertifikat,
                 keepAlive: true
             );
 

--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
@@ -17,7 +17,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var kontoId = Guid.NewGuid();
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
-            var certificat = new X509Certificate2();
+            var maskinportenSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateProdConfiguration(
                 integrasjonId: integrationId,
@@ -25,7 +25,8 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 kontoId: kontoId,
                 privatNokkel: privatNokkel,
                 issuer: issuer,
-                sertifikat: certificat);
+                maskinportenSertifikat: maskinportenSertifikat,
+                asiceSertifikat: maskinportenSertifikat);
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
@@ -43,7 +44,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var kontoId = Guid.NewGuid();
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
-            var certificat = new X509Certificate2();
+            var maskinportenSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateProdConfiguration(
                 integrasjonId: integrationId,
@@ -51,7 +52,8 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 kontoId: kontoId,
                 privatNokkel: privatNokkel,
                 issuer: issuer,
-                sertifikat: certificat,
+                maskinportenSertifikat: maskinportenSertifikat,
+                asiceSertifikat: maskinportenSertifikat,
                 keepAlive: true);
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
@@ -70,7 +72,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var kontoId = Guid.NewGuid();
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
-            var certificat = new X509Certificate2();
+            var maskinportenSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateTestConfiguration(
                 fiksIntegrasjonId: integrationId,
@@ -78,7 +80,8 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 fiksKontoId: kontoId,
                 privatNokkel: privatNokkel,
                 issuer: issuer,
-                sertifikat: certificat
+                maskinportenSertifikat: maskinportenSertifikat,
+                asiceSertifikat: maskinportenSertifikat
             );
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
@@ -97,7 +100,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             var kontoId = Guid.NewGuid();
             var privatNokkel = Guid.NewGuid().ToString();
             var issuer = Guid.NewGuid().ToString();
-            var certificat = new X509Certificate2();
+            var maskinportenSertifikat = new X509Certificate2();
 
             var config = FiksIOConfiguration.CreateTestConfiguration(
                 fiksIntegrasjonId: integrationId,
@@ -105,7 +108,8 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 fiksKontoId: kontoId,
                 privatNokkel: privatNokkel,
                 issuer: issuer,
-                sertifikat: certificat,
+                maskinportenSertifikat: maskinportenSertifikat,
+                asiceSertifikat: maskinportenSertifikat,
                 keepAlive: true
             );
 

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using KS.Fiks.IO.Client.Amqp;
+using KS.Fiks.IO.Client.Asic;
 using KS.Fiks.IO.Client.Catalog;
 using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Client.Dokumentlager;
@@ -38,6 +39,7 @@ namespace KS.Fiks.IO.Client.Tests
             SendHandlerMock = new Mock<ISendHandler>();
             DokumentlagerHandlerMock = new Mock<IDokumentlagerHandler>();
             AmqpHandlerMock = new Mock<IAmqpHandler>();
+            AsicEncrypterMock = new Mock<IAsicEncrypter>();
         }
 
         public Mock<IMaskinportenClient> MaskinportenClientMock { get; }
@@ -45,6 +47,8 @@ namespace KS.Fiks.IO.Client.Tests
         public Mock<IFiksIOSender> FiksIOSenderMock { get; }
 
         public Mock<ISendHandler> SendHandlerMock { get; }
+
+        public Mock<IAsicEncrypter> AsicEncrypterMock { get; }
 
         public MeldingRequest DefaultRequest => new MeldingRequest(
             Guid.NewGuid(),
@@ -61,7 +65,8 @@ namespace KS.Fiks.IO.Client.Tests
                 MaskinportenClientMock.Object,
                 SendHandlerMock.Object,
                 DokumentlagerHandlerMock.Object,
-                AmqpHandlerMock.Object).Result;
+                AmqpHandlerMock.Object,
+                asicEncrypter: AsicEncrypterMock.Object).Result;
         }
 
         public FiksIOClientFixture WithAccountId(Guid id)
@@ -132,11 +137,11 @@ namespace KS.Fiks.IO.Client.Tests
         {
             var apiConfiguration = new ApiConfiguration(_scheme, _host, _port);
             var accountConfiguration = new KontoConfiguration(_accountId, "dummyKey");
-
             _configuration = new FiksIOConfiguration(
                 accountConfiguration,
                 new IntegrasjonConfiguration(_integrasjonId, _integrasjonPassword),
                 new MaskinportenClientConfiguration("audience", "token", "issuer", 1, new X509Certificate2()),
+                new AsiceSigningConfiguration("",""),
                 apiConfiguration: apiConfiguration,
                 katalogConfiguration: _katalogConfiguration);
         }

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5-build.20230103122919779" />
+        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5" />
         <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.3" />
         <PackageReference Include="Moq" Version="4.18.3" />

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4" />
+        <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5-build.20230103122919779" />
         <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.3" />
         <PackageReference Include="Moq" Version="4.18.3" />

--- a/KS.Fiks.IO.Client/Asic/AsicSigningCertificateHolderFactory.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicSigningCertificateHolderFactory.cs
@@ -1,11 +1,18 @@
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using KS.Fiks.ASiC_E.Crypto;
+using KS.Fiks.IO.Client.Configuration;
 
 namespace KS.Fiks.IO.Client.Asic
 {
-    public class AsicSigningCertificateHolderFactory
+    public static class AsicSigningCertificateHolderFactory
     {
-        public static PreloadedCertificateHolder Create(string publicKeyPath, string privateKeyPath)
+        public static PreloadedCertificateHolder Create(AsiceSigningConfiguration configuration)
+        {
+            return configuration.certificate != null ? Create(configuration.certificate) : Create(configuration.publicCertPath, configuration.privateKeyPath);
+        }
+
+        private static PreloadedCertificateHolder Create(string publicKeyPath, string privateKeyPath)
         {
             using (var publicKeyStream = new FileStream(publicKeyPath, FileMode.Open))
             using (var privateKeyStream = new FileStream(privateKeyPath, FileMode.Open))
@@ -19,6 +26,11 @@ namespace KS.Fiks.IO.Client.Asic
                         privateKeyBufferStream.ToArray());
                 }
             }
+        }
+
+        private static PreloadedCertificateHolder Create(X509Certificate2 x509Certificate2)
+        {
+            return PreloadedCertificateHolder.Create(x509Certificate2);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Configuration/AsiceSigningConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/AsiceSigningConfiguration.cs
@@ -1,14 +1,22 @@
+using System.Security.Cryptography.X509Certificates;
+
 namespace KS.Fiks.IO.Client.Configuration
 {
     public class AsiceSigningConfiguration
     {
-        public string publicCertPath;
-        public string privateKeyPath;
+        public readonly string publicCertPath;
+        public readonly string privateKeyPath;
+        public X509Certificate2 certificate;
 
         public AsiceSigningConfiguration(string publicCertPath, string privateKeyPath)
         {
             this.publicCertPath = publicCertPath;
             this.privateKeyPath = privateKeyPath;
+        }
+
+        public AsiceSigningConfiguration(X509Certificate2 x509Certificate2)
+        {
+            certificate = x509Certificate2;
         }
     }
 }

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
@@ -27,12 +27,13 @@ namespace KS.Fiks.IO.Client.Configuration
             KontoConfiguration kontoConfiguration,
             IntegrasjonConfiguration integrasjonConfiguration,
             MaskinportenClientConfiguration maskinportenConfiguration,
+            AsiceSigningConfiguration asiceSigningConfiguration,
             ApiConfiguration apiConfiguration = null,
             AmqpConfiguration amqpConfiguration = null,
             KatalogConfiguration katalogConfiguration = null,
             FiksIOSenderConfiguration fiksIOSenderConfiguration = null,
-            DokumentlagerConfiguration dokumentlagerConfiguration = null,
-            AsiceSigningConfiguration asiceSigningConfiguration = null)
+            DokumentlagerConfiguration dokumentlagerConfiguration = null
+            )
         {
             KontoConfiguration = kontoConfiguration;
             IntegrasjonConfiguration = integrasjonConfiguration;
@@ -63,7 +64,8 @@ namespace KS.Fiks.IO.Client.Configuration
             Guid kontoId,
             string privatNokkel,
             string issuer,
-            X509Certificate2 sertifikat,
+            X509Certificate2 maskinportenSertifikat,
+            X509Certificate2 asiceSertifikat,
             bool keepAlive = false,
             string applicationName = null)
         {
@@ -72,7 +74,8 @@ namespace KS.Fiks.IO.Client.Configuration
                 apiConfiguration: ApiConfiguration.CreateProdConfiguration(),
                 integrasjonConfiguration: new IntegrasjonConfiguration(integrasjonId, integrasjonPassord),
                 kontoConfiguration: new KontoConfiguration(kontoId, privatNokkel),
-                maskinportenConfiguration: CreateMaskinportenProdConfig(issuer, sertifikat));
+                maskinportenConfiguration: CreateMaskinportenProdConfig(issuer, maskinportenSertifikat),
+                asiceSigningConfiguration: new AsiceSigningConfiguration(asiceSertifikat));
         }
 
         public static FiksIOConfiguration CreateTestConfiguration(
@@ -81,7 +84,8 @@ namespace KS.Fiks.IO.Client.Configuration
             Guid fiksKontoId,
             string privatNokkel,
             string issuer,
-            X509Certificate2 sertifikat,
+            X509Certificate2 maskinportenSertifikat,
+            X509Certificate2 asiceSertifikat,
             bool keepAlive = false,
             string applicationName = null)
         {
@@ -90,7 +94,8 @@ namespace KS.Fiks.IO.Client.Configuration
                 apiConfiguration: ApiConfiguration.CreateTestConfiguration(),
                 integrasjonConfiguration: new IntegrasjonConfiguration(fiksIntegrasjonId, fiksIntegrasjonPassord),
                 kontoConfiguration: new KontoConfiguration(fiksKontoId, privatNokkel),
-                maskinportenConfiguration: CreateMaskinportenTestConfig(issuer, sertifikat));
+                maskinportenConfiguration: CreateMaskinportenTestConfig(issuer, maskinportenSertifikat),
+                asiceSigningConfiguration: new AsiceSigningConfiguration(asiceSertifikat));
         }
 
         public static MaskinportenClientConfiguration CreateMaskinportenProdConfig(string issuer, X509Certificate2 certificate)

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -9,7 +9,7 @@ namespace KS.Fiks.IO.Client.Configuration
         private AmqpConfiguration _amqpConfiguration;
         private IntegrasjonConfiguration _integrasjonConfiguration;
         private KontoConfiguration _kontoConfiguration;
-        private AsiceSigningConfiguration _asiceSigningConfiguration = null;
+        private AsiceSigningConfiguration _asiceSigningConfiguration;
         private bool ampqKeepAlive = false;
         private string amqpApplicationName = string.Empty;
         private ushort amqpPrefetchCount = 10;
@@ -57,6 +57,12 @@ namespace KS.Fiks.IO.Client.Configuration
         public FiksIOConfigurationBuilder WithAsiceSigningConfiguration(string certificatePath, string certificatePrivateKeyPath)
         {
             _asiceSigningConfiguration = new AsiceSigningConfiguration(certificatePath, certificatePrivateKeyPath);
+            return this;
+        }
+        
+        public FiksIOConfigurationBuilder WithAsiceSigningConfiguration(X509Certificate2 x509Certificate2)
+        {
+            _asiceSigningConfiguration = new AsiceSigningConfiguration(x509Certificate2);
             return this;
         }
 

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -51,7 +51,8 @@ namespace KS.Fiks.IO.Client
             IDokumentlagerHandler dokumentlagerHandler = null,
             IAmqpHandler amqpHandler = null,
             HttpClient httpClient = null,
-            IPublicKeyProvider publicKeyProvider = null)
+            IPublicKeyProvider publicKeyProvider = null,
+            IAsicEncrypter asicEncrypter = null)
         {
             KontoId = configuration.KontoConfiguration.KontoId;
 
@@ -65,20 +66,10 @@ namespace KS.Fiks.IO.Client
 
             _publicKeyProvider = publicKeyProvider ?? new CatalogPublicKeyProvider(_catalogHandler);
 
-            AsicEncrypter asicEncrypter;
-            if (configuration.AsiceSigningConfiguration != null)
-            {
-                 asicEncrypter = new AsicEncrypter(
+            var _asicEncrypter = asicEncrypter ?? new AsicEncrypter(
                      new AsiceBuilderFactory(), 
                      new EncryptionServiceFactory(), 
-                     AsicSigningCertificateHolderFactory.Create(
-                        configuration.AsiceSigningConfiguration.publicCertPath,
-                        configuration.AsiceSigningConfiguration.privateKeyPath));
-            }
-            else
-            {
-                asicEncrypter = new AsicEncrypter(new AsiceBuilderFactory(), new EncryptionServiceFactory());
-            }
+                     AsicSigningCertificateHolderFactory.Create(configuration.AsiceSigningConfiguration));
 
             _sendHandler = sendHandler ??
                            new SendHandler(
@@ -87,7 +78,7 @@ namespace KS.Fiks.IO.Client
                                configuration.FiksIOSenderConfiguration,
                                configuration.IntegrasjonConfiguration,
                                httpClient,
-                               asicEncrypter,
+                               _asicEncrypter,
                                _publicKeyProvider);
 
             _dokumentlagerHandler = dokumentlagerHandler ?? new DokumentlagerHandler(
@@ -114,7 +105,8 @@ namespace KS.Fiks.IO.Client
             IDokumentlagerHandler dokumentlagerHandler = null,
             IAmqpHandler amqpHandler = null,
             HttpClient httpClient = null,
-            IPublicKeyProvider publicKeyProvider = null)
+            IPublicKeyProvider publicKeyProvider = null,
+            IAsicEncrypter asicEncrypter = null)
         {
             var client = new FiksIOClient(
                 configuration,
@@ -124,7 +116,8 @@ namespace KS.Fiks.IO.Client
                 dokumentlagerHandler, 
                 amqpHandler,
                 httpClient, 
-                publicKeyProvider);
+                publicKeyProvider,
+                asicEncrypter);
 
             await client.InitializeAsync(configuration).ConfigureAwait(false);
 

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -12,12 +12,12 @@
 		<RepositoryUrl>https://github.com/ks-no/fiks-io-client-dotnet.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>FIKS</PackageTags>
-		<VersionPrefix>2.0.7</VersionPrefix>
+		<VersionPrefix>3.0.0</VersionPrefix>
 		<TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<AssemblyVersion>2.0.0.0</AssemblyVersion>
-		<FileVersion>2.0.0.0</FileVersion>
+		<AssemblyVersion>3.0.0.0</AssemblyVersion>
+		<FileVersion>3.0.0.0</FileVersion>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>../fiks-io-strongly-named-key.snk</AssemblyOriginatorKeyFile>

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -42,7 +42,7 @@
 		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5-build.20230103122919779" />
+		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5" />
 		<PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.3" />

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -42,7 +42,7 @@
 		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.4" />
+		<PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5-build.20230103122919779" />
 		<PackageReference Include="KS.Fiks.Crypto" Version="1.0.4" />
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.8" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.3" />


### PR DESCRIPTION
Asice configuration er nå påkrevd med denne endringen

Vi gjør det slik nå at man må konfigurere fiks-io-client til å signere. Det kan gjøres ved public+private key eller en x509certificate2 som har en privatekey. Dette betyr at dette blir en "breaking change" mtp at man må sette opp Fiks-IO klienten for asice signering. 

Bumper til 3.0.x