### PR TITLE
Korreksjon mtp static 

### DIFF
--- a/ExampleApplication/Program.cs
+++ b/ExampleApplication/Program.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.IO;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
+﻿using System.IO;
 using System.Threading.Tasks;
 using ExampleApplication.FiksIO;
 using KS.Fiks.IO.Client;
-using KS.Fiks.IO.Client.Configuration;
-using KS.Fiks.IO.Client.Models;
-using Ks.Fiks.Maskinporten.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -16,17 +16,18 @@ namespace KS.Fiks.IO.Client.Amqp
 {
     internal class AmqpHandler : IAmqpHandler
     {
+        private static ILogger<AmqpHandler> _logger;
+
         private const string QueuePrefix = "fiksio.konto.";
 
-        private static IConnectionFactory _connectionFactory;
+        private IConnectionFactory _connectionFactory;
 
-        private static IMaskinportenClient _maskinportenClient;
+        private IMaskinportenClient _maskinportenClient;
 
-        private static IntegrasjonConfiguration _integrasjonConfiguration;
+        private IntegrasjonConfiguration _integrasjonConfiguration;
 
-        private static IConnection _connection;
+        private IConnection _connection;
 
-        private static ILogger<AmqpHandler> _logger;
 
         private readonly IAmqpConsumerFactory _amqpConsumerFactory;
 

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -97,6 +97,7 @@ namespace KS.Fiks.IO.Client.Configuration
             ampqKeepAlive = keepAlive;
             amqpApplicationName = applicationName;
             amqpPrefetchCount = prefetchCount;
+            ampqKeepAliveHealthCheckInterval = keepAliveHealthCheckInterval;
             return this;
         }
 

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -23,15 +23,15 @@ namespace KS.Fiks.IO.Client
 {
     public class FiksIOClient : IFiksIOClient
     {
-        private static ISendHandler _sendHandler;
+        private ISendHandler _sendHandler;
 
-        private static ILoggerFactory _loggerFactory;
+        private ILoggerFactory _loggerFactory;
 
-        private static IAmqpHandler _amqpHandler;
+        private IAmqpHandler _amqpHandler;
 
-        private static IDokumentlagerHandler _dokumentlagerHandler;
+        private IDokumentlagerHandler _dokumentlagerHandler;
 
-        private static IMaskinportenClient _maskinportenClient;
+        private IMaskinportenClient _maskinportenClient;
 
         private readonly ICatalogHandler _catalogHandler;
 
@@ -102,7 +102,7 @@ namespace KS.Fiks.IO.Client
             IPublicKeyProvider publicKeyProvider = null)
         {
             var client = new FiksIOClient(configuration, loggerFactory, httpClient, publicKeyProvider);
-            await InitializeAmqpHandlerAsync(configuration).ConfigureAwait(false);
+            await client.InitializeAmqpHandlerAsync(configuration).ConfigureAwait(false);
             return client;
         }
 
@@ -118,7 +118,6 @@ namespace KS.Fiks.IO.Client
             IPublicKeyProvider publicKeyProvider = null,
             IAsicEncrypter asicEncrypter = null)
         {
-
             var client = new FiksIOClient(
                 configuration,
                 loggerFactory,
@@ -131,11 +130,11 @@ namespace KS.Fiks.IO.Client
                 publicKeyProvider,
                 asicEncrypter);
 
-            await InitializeAmqpHandlerAsync(configuration).ConfigureAwait(false);
+            await client.InitializeAmqpHandlerAsync(configuration).ConfigureAwait(false);
             return client;
         }
 
-        private static async Task InitializeAmqpHandlerAsync(FiksIOConfiguration configuration)
+        private async Task InitializeAmqpHandlerAsync(FiksIOConfiguration configuration)
         {
             _amqpHandler = _amqpHandler ?? await AmqpHandler.CreateAsync(
                 _maskinportenClient,


### PR DESCRIPTION
Det ble feil mtp static felter som f.eks. amqpHandler. 
Dette er en glipp som heller ikke ble oppdaget i integresjonstester. 
Utvider tester til å oppdage slike feil i framtiden.