### PR TITLE
Lagt på mere informasjon om oppsett av Fiks-IO-Client

### DIFF
--- a/ExampleApplication/README.md
+++ b/ExampleApplication/README.md
@@ -1,0 +1,71 @@
+# Example Application for Fiks-IO-Client
+
+## How it works
+
+This application starts a simple console application that starts a subscription to Fiks-IO/Fiks-Protokoll messages as a BackgroundService in the [FiksIOSubscriber.cs](FiksIO/FiksIOSubscriber.cs) class.
+
+It also listens to the Enter key to send a message to it self, through it's own Fiks-IO account, with the [MessageSender.cs](FiksIO/MessageSender.cs) class. The message sent is a simple 'ping'-message that the [FiksIOSubcriber.cs](FiksIO/FiksIOSubscriber.cs) class replies with a 'pong'-message.
+
+This is a very simple example of sending, receiving and replying to messages with this Fiks-IO-Client that logs information on the messages.
+
+The program will also periodically print the status of the _IsOpen()_ health status of the Fiks-IO connection. The _IsOpen()_ method can be used for health checking. 
+
+## Getting started
+
+You will need a Fiks-Protokoll or a Fiks-IO account. See documentation on how at the [developers.fiks.ks.no](https://developers.fiks.ks.no/tjenester/fiksprotokoll/#hvordan-komme-i-gang-med-fiks-protokoll) portal.
+
+## Configuration
+
+The [appsettings.json](appsettings.json) file is for configuration of the Fiks-IO-client in this example application.
+This file is then used by the [FikIOConfigurationBuilder.cs](FiksIO/FiksIOConfigurationBuilder.cs) class for setting up the client.
+
+The [FikIOConfigurationBuilder.cs](FiksIO/FiksIOConfigurationBuilder.cs) in this example project uses the Fluent builder that is included in the Fiks-IO-Client. 
+This is even more helpful with setting up a test or production client for you.
+
+### appsettings.json
+Here is the example appsetting.json file with hopefully some helpful comments:
+
+```json
+{
+  "AppSettings": {
+    "FiksIOConfig": {
+        "ApiHost": "api.fiks.test.ks.no", // API host adress. Test: api.fiks.test.ks.no", Prod: "api.fiks.ks.no"
+        "ApiPort": "443", // Port for the API host. 433 is correct
+        "ApiScheme": "https", // Schema for the API. HTTPS is correct
+        "AmqpHost": "io.fiks.test.ks.no", // AMQP host adress for message subscribe. Test: "io.fiks.test.ks.no", Prod: "io.fiks.ks.no" 
+        "AmqpPort": "5671",  // AMQP host port for message subscribe. 5671 is correct
+        "FiksIoAccountId": "<your account>", // Your Fiks Protokoll (Fiks-IO) account id
+        "FiksIoIntegrationId": "<your integration id>", // Your Fiks Protokoll (Fiks-IO) integration id
+        "FiksIoIntegrationPassword": "<your integration password>", // Your Fiks Protokoll (Fiks-IO) integration password
+        "FiksIoIntegrationScope": "ks:fiks", // Leave this as it is
+        "FiksIoPrivateKey": "<path to private key>", // Path to the private key that is paired with the public key uploaded to your Fiks Protokoll (Fiks-IO) account
+        "MaskinPortenAudienceUrl": "https://ver2.maskinporten.no/", // Maskinporten Audience url. This is correct and leave it as it is
+        "MaskinPortenCompanyCertificateThumbprint": "<your thumbprint>", // The thumbprint for the certificate used with Maskinporten
+        "MaskinPortenCompanyCertificatePath": "", // The path to the certificate used with Maskinporten
+        "MaskinPortenCompanyCertificatePassword": "", // The password for the certificate used with Maskinporten
+        "MaskinPortenIssuer": "", // Maskinporten issuer
+        "MaskinPortenTokenUrl": "https://ver2.maskinporten.no/token", // Token url for Maskinporten. Leave this as it is.
+        "AsiceSigningPrivateKey": "", // The path to the private key for AsiceSigning of the payloads.
+        "AsiceSigningPublicKey": "" // The path to the public key for verification of AsiceSigning of the payloads.
+    }
+  }
+}
+```
+
+Here are some explanations:
+
+#### FiksIoPrivateKey
+This is the private key that is paired with the public key uploaded to your Fiks Protokoll (Fiks-IO) account.
+It is not related to the Maskinporten certificate, but the private key part from a generated key-pair. It is used for decrypting messages that is encrypted by the sender of messages with the public key uploaded to Fiks-Protokoll.
+
+#### MaskinPortenXXX settings
+Please look at the documentation at [developers.ks.fiks.no](https://developers.fiks.ks.no/felles/difiidportenklient/) for further explanations.
+
+#### AsiceSigningPrivateKey
+This is a path to a private key that you want to use for Asice signing. In this example application it must be a private key of a generated public/private key pair.
+But you can also use a private key linked to the Maskinporten certificate if you like when setting up the Fiks-IO-Client. Then you must provide a single file containing the certificate and the privatekey and use a different method of the configuration builder in the Fiks-IO-Client.
+
+#### AsiceSigningPublicKey
+This is a path to a public key that you want to use for Asice signing verification. In this example application it must be a public key of a generated public/private key pair.
+
+

--- a/ExampleApplication/README.md
+++ b/ExampleApplication/README.md
@@ -39,12 +39,12 @@ Here is the example appsetting.json file with hopefully some helpful comments:
         "FiksIoIntegrationPassword": "<your integration password>", // Your Fiks Protokoll (Fiks-IO) integration password
         "FiksIoIntegrationScope": "ks:fiks", // Leave this as it is
         "FiksIoPrivateKey": "<path to private key>", // Path to the private key that is paired with the public key uploaded to your Fiks Protokoll (Fiks-IO) account
-        "MaskinPortenAudienceUrl": "https://ver2.maskinporten.no/", // Maskinporten Audience url. This is correct and leave it as it is
+        "MaskinPortenAudienceUrl": "https://ver2.maskinporten.no/", // Maskinporten Audience url. Test: "https://ver2.maskinporten.no", Prod: "https://maskinporten.no"
         "MaskinPortenCompanyCertificateThumbprint": "<your thumbprint>", // The thumbprint for the certificate used with Maskinporten
         "MaskinPortenCompanyCertificatePath": "", // The path to the certificate used with Maskinporten
         "MaskinPortenCompanyCertificatePassword": "", // The password for the certificate used with Maskinporten
         "MaskinPortenIssuer": "", // Maskinporten issuer
-        "MaskinPortenTokenUrl": "https://ver2.maskinporten.no/token", // Token url for Maskinporten. Leave this as it is.
+        "MaskinPortenTokenUrl": "https://ver2.maskinporten.no/token", // Token url for Maskinporten. Test: "https://ver2.maskinporten.no/token", Prod: "https://maskinporten.no/token" 
         "AsiceSigningPrivateKey": "", // The path to the private key for AsiceSigning of the payloads.
         "AsiceSigningPublicKey": "" // The path to the public key for verification of AsiceSigning of the payloads.
     }

--- a/ExampleApplication/README.md
+++ b/ExampleApplication/README.md
@@ -56,7 +56,7 @@ Here are some explanations:
 
 #### FiksIoPrivateKey
 This is the private key that is paired with the public key uploaded to your Fiks Protokoll (Fiks-IO) account.
-It is not related to the Maskinporten certificate, but the private key part from a generated key-pair. It is used for decrypting messages that is encrypted by the sender of messages with the public key uploaded to Fiks-Protokoll.
+It is not related to the Maskinporten certificate, but the private key part from a generated key pair. It is used for decrypting messages that is encrypted by the sender of messages with the public key uploaded to Fiks-Protokoll.
 
 #### MaskinPortenXXX settings
 Please look at the documentation at [developers.ks.fiks.no](https://developers.fiks.ks.no/felles/difiidportenklient/) for further explanations.

--- a/ExampleApplication/appsettings.json
+++ b/ExampleApplication/appsettings.json
@@ -18,7 +18,7 @@
       "MaskinPortenIssuer": "",
       "MaskinPortenTokenUrl": "https://ver2.maskinporten.no/token",
       "AsiceSigningPrivateKey": "",
-      "AsiceSigningPublicKey": "",
+      "AsiceSigningPublicKey": ""
     }
   }
 }

--- a/KS.Fiks.IO.Client/Asic/AsicSigningCertificateHolderFactory.cs
+++ b/KS.Fiks.IO.Client/Asic/AsicSigningCertificateHolderFactory.cs
@@ -9,7 +9,7 @@ namespace KS.Fiks.IO.Client.Asic
     {
         public static PreloadedCertificateHolder Create(AsiceSigningConfiguration configuration)
         {
-            return configuration.certificate != null ? Create(configuration.certificate) : Create(configuration.publicCertPath, configuration.privateKeyPath);
+            return configuration.Certificate != null ? Create(configuration.Certificate) : Create(configuration.PublicKeyPath, configuration.PrivateKeyPath);
         }
 
         private static PreloadedCertificateHolder Create(string publicKeyPath, string privateKeyPath)

--- a/KS.Fiks.IO.Client/Configuration/AsiceSigningConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/AsiceSigningConfiguration.cs
@@ -4,19 +4,25 @@ namespace KS.Fiks.IO.Client.Configuration
 {
     public class AsiceSigningConfiguration
     {
-        public readonly string publicCertPath;
-        public readonly string privateKeyPath;
-        public X509Certificate2 certificate;
+        public readonly string PublicKeyPath;
+        public readonly string PrivateKeyPath;
+        public readonly X509Certificate2 Certificate;
 
-        public AsiceSigningConfiguration(string publicCertPath, string privateKeyPath)
+        /*
+         * A public/private key pair
+         */
+        public AsiceSigningConfiguration(string publicKeyPath, string privateKeyPath)
         {
-            this.publicCertPath = publicCertPath;
-            this.privateKeyPath = privateKeyPath;
+            PublicKeyPath = publicKeyPath;
+            PrivateKeyPath = privateKeyPath;
         }
 
+       /*
+        * The x509Certificate2 parameter must be a x509Certificate that holds a matching private key
+        */
         public AsiceSigningConfiguration(X509Certificate2 x509Certificate2)
         {
-            certificate = x509Certificate2;
+            Certificate = x509Certificate2;
         }
     }
 }

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -82,12 +82,18 @@ namespace KS.Fiks.IO.Client.Configuration
             return this;
         }
 
-        public FiksIOConfigurationBuilder WithAsiceSigningConfiguration(string certificatePath, string certificatePrivateKeyPath)
+        /*
+         * AsiceSigning with public/private key pair
+         */
+        public FiksIOConfigurationBuilder WithAsiceSigningConfiguration(string publicKeyPath, string privateKeyPath)
         {
-            _asiceSigningConfiguration = new AsiceSigningConfiguration(certificatePath, certificatePrivateKeyPath);
+            _asiceSigningConfiguration = new AsiceSigningConfiguration(publicKeyPath, privateKeyPath);
             return this;
         }
 
+        /*
+         * AsiceSigning with a X509Certificate2 that must contain a matching privatekey. This can be the same as used for Maskinporten
+         */
         public FiksIOConfigurationBuilder WithAsiceSigningConfiguration(X509Certificate2 x509Certificate2)
         {
             _asiceSigningConfiguration = new AsiceSigningConfiguration(x509Certificate2);

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 Fiks IO is a messaging system for the public sector in Norway. [About Fiks IO (Norwegian)](https://ks-no.github.io/fiks-plattform/tjenester/fiksprotokoll/fiksio/)
 
-It is also the underlying messaging system for the Fiks Protokoll messages. Read more about Fiks Protokoll [here](https://ks-no.github.io/fiks-plattform/tjenester/fiksprotokoll/)
+
+It is also the underlying messaging system for the **Fiks Protokoll** messages. Read more about Fiks Protokoll [here](https://ks-no.github.io/fiks-plattform/tjenester/fiksprotokoll/)
 
 ### Simplifying Fiks-IO
 This client and its corresponding clients for other languages released by KS simplify the authentication, encryption of messages, and communication through Fiks-IO. 
@@ -38,14 +39,16 @@ We recommend using this for monitoring the health of the client.
 ## Examples
 
 ### Example project
-An example project is provided [here](ExampleApplication) in the `ExampleApplication` and the Program.cs program. 
-This example program shows how to create a Fiks-IO-Client, subscribe, send and reply to messages. 
+An example project is provided [here](ExampleApplication) in the `ExampleApplication` and the [Program.cs](ExampleApplication/Program.cs) program. 
+This example program shows how to create a Fiks-IO-Client, subscribe, send and reply to messages.
 
 The example project starts a console program that listens and subscribes to messages on your Fiks-IO account. 
 It listens to the Enter key in the console, that then triggers it to send a 'ping' message to your Fiks-IO account.
 When the program receives the 'ping' message it will reply to that message with a 'pong' message. 
 
 The program also adds the optional 'klientMeldingId' when sending messages and utilizes the IsOpen() feature to show the connection-status.
+
+Read more in the [README.md](ExampleApplication/README.md) file for the example application.
 
 ### Sending message
 ```csharp


### PR DESCRIPTION
Lenke til ny egen README for ExampleApplication som forklarer litt mer om hva alt er.
Lagt på litt dokumentasjon rundt Asice signering og konfigurasjon i koden og forandret navn på parametere da det var forvirrende bruk av "cert" navn der det egentlig er public/private nøkler. 