### PR TITLE
Fikset mangel i config builder og README

### DIFF
--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIOConfigurationBuilderTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIOConfigurationBuilderTests.cs
@@ -17,6 +17,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .Init()
                 .WithAmqpConfiguration("test_app", 10)
                 .WithMaskinportenConfiguration(new X509Certificate2(), "test-issuer")
+                .WithAsiceSigningConfiguration(new X509Certificate2())
                 .WithFiksIntegrasjonConfiguration(Guid.NewGuid(), "passord")
                 .WithFiksKontoConfiguration(Guid.NewGuid(), "liksom-en-private-key")
                 .BuildTestConfiguration();
@@ -32,6 +33,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .Init()
                 .WithAmqpConfiguration("test_app", 10)
                 .WithMaskinportenConfiguration(new X509Certificate2(), "test-issuer")
+                .WithAsiceSigningConfiguration(new X509Certificate2())
                 .WithFiksIntegrasjonConfiguration(Guid.NewGuid(), "passord")
                 .WithFiksKontoConfiguration(Guid.NewGuid(), "liksom-en-private-key")
                 .BuildProdConfiguration();
@@ -48,6 +50,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .Init()
                 .WithAmqpConfiguration(Guid.NewGuid().ToString(), 10)
                 .WithMaskinportenConfiguration(new X509Certificate2(), Guid.NewGuid().ToString())
+                .WithAsiceSigningConfiguration(new X509Certificate2())
                 .WithFiksIntegrasjonConfiguration(Guid.NewGuid(), Guid.NewGuid().ToString())
                 .WithFiksKontoConfiguration(Guid.NewGuid(), dummyPrivateKey)
                 .BuildTestConfiguration();
@@ -63,6 +66,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .Init()
                 .WithAmqpConfiguration(Guid.NewGuid().ToString(), 10)
                 .WithMaskinportenConfiguration(new X509Certificate2(), Guid.NewGuid().ToString())
+                .WithAsiceSigningConfiguration(new X509Certificate2())
                 .WithFiksIntegrasjonConfiguration(Guid.NewGuid(), Guid.NewGuid().ToString())
                 .WithFiksKontoConfiguration(Guid.NewGuid(), dummyPrivateKeys)
                 .BuildTestConfiguration();
@@ -78,6 +82,19 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                     .Init()
                     .WithAmqpConfiguration("test_app", 10)
                     .WithMaskinportenConfiguration(null, "test-issuer")
+                    .WithFiksIntegrasjonConfiguration(Guid.NewGuid(), "passord")
+                    .WithFiksKontoConfiguration(Guid.NewGuid(), "liksom-en-private-key")
+                    .BuildProdConfiguration());
+        }
+
+        [Fact]
+        public void ConfigurationFailsWithoutAsiceSigningConfiguration()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                FiksIOConfigurationBuilder
+                    .Init()
+                    .WithAmqpConfiguration("test_app", 10)
+                    .WithMaskinportenConfiguration(new X509Certificate2(), "test-issuer")
                     .WithFiksIntegrasjonConfiguration(Guid.NewGuid(), "passord")
                     .WithFiksKontoConfiguration(Guid.NewGuid(), "liksom-en-private-key")
                     .BuildProdConfiguration());

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -129,7 +129,6 @@ namespace KS.Fiks.IO.Client.Configuration
 
         public FiksIOConfigurationBuilder WithApiConfiguration(string hostName, int hostPort)
         {
-            
             return this;
         }
 
@@ -151,6 +150,12 @@ namespace KS.Fiks.IO.Client.Configuration
             {
                 throw new ArgumentException(
                     "FiksKontoConfiguration missing. Have you called the WithFiksKontoConfiguration( ... ) in this builder?");
+            }
+
+            if (_asiceSigningConfiguration == null)
+            {
+                throw new ArgumentException(
+                    "AsiceSigningConfiguration missing. Have you called the WithAsiceSigningConfiguration( ... ) in this builder?");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -151,28 +151,55 @@ You can also create the configuration yourself where also two convenience functi
 #### Logging
 Logging is available by providing the Fiks-IO-Client with a ILoggerFactory. Example of this is provided in the ExampleApplication project.
 
-#### Create with builder example:
+#### Create with builder examples:
 
 ```csharp
-// Prod config
+
+// Prod alternative 1
+// Prod config with public/private key for asice signing
 var config = FiksIOConfigurationBuilder
                 .Init()
-                .WithAmqpConfiguration("fiks-io-klient-prod-program-2", 1) // Optional but recomended: default values will be no applicationname, 10 prefetch count, and keepAlive = false
+                .WithAmqpConfiguration("My unique name for this application", 1) // Optional but recomended: default values will be a generated application name, 10 prefetch count, and keepAlive = false
                 .WithMaskinportenConfiguration(certificate, issuer)
                 .WithFiksIntegrasjonConfiguration(integrationId, integrationPassword)
                 .WithFiksKontoConfiguration(kontoId, privateKey) // privateKey is the private key associated with the public key uploaded to your fiks-io/fiks-protokoll account
                 .WithAsiceSigningConfiguration(asicePublicKeyFilepath, asicePrivateKeyPath) // A public/private key pair to sign the asice packages
                 .BuildProdConfiguration();
-
-// Test config
+                
+                
+// Prod alternative 2
+// Prod config with a X509Certificate2 certificate for asice signing
 var config = FiksIOConfigurationBuilder
                 .Init()
-                .WithAmqpConfiguration("fiks-io-klient-test-program-2", 1) // Optional but recomended: default values will be no applicationname, 10 prefetch count, and keepAlive = false
+                .WithAmqpConfiguration("My unique name for this application", 1) // Optional but recomended: default values will be a generated application name, 10 prefetch count, and keepAlive = false
+                .WithMaskinportenConfiguration(certificate, issuer)
+                .WithFiksIntegrasjonConfiguration(integrationId, integrationPassword)
+                .WithFiksKontoConfiguration(kontoId, privateKey) // privateKey is the private key associated with the public key uploaded to your fiks-io/fiks-protokoll account
+                .WithAsiceSigningConfiguration(certificate2) // A X509Certificate2 certificate that also contains the private key
+                .BuildProdConfiguration();
+
+// Test alternative 1
+// Test config with public/private key for asice signing
+var config = FiksIOConfigurationBuilder
+                .Init()
+                .WithAmqpConfiguration("My unique name for this application", 1) // Optional but recomended: default values will be a generated applicationname, 10 prefetch count, and keepAlive = false
                 .WithMaskinportenConfiguration(certificate, issuer)
                 .WithFiksIntegrasjonConfiguration(integrationId, integrationPassword)
                 .WithFiksKontoConfiguration(kontoId, privateKey) // privateKey is the private key associated with the public key uploaded to your fiks-io/fiks-protokoll account
                 .WithAsiceSigningConfiguration(asicePublicKeyFilepath, asicePrivateKeyPath) //  A public/private key pair to sign the asice packages
                 .BuildTestConfiguration();
+            
+// Test alternative 2
+// Test config with a X509Certificate2 certificate for asice signing
+var config = FiksIOConfigurationBuilder
+                .Init()
+                .WithAmqpConfiguration("My unique name for this application", 1) // Optional but recomended: default values will be a generated applicationname, 10 prefetch count, and keepAlive = false
+                .WithMaskinportenConfiguration(certificate, issuer)
+                .WithFiksIntegrasjonConfiguration(integrationId, integrationPassword)
+                .WithFiksKontoConfiguration(kontoId, privateKey) // privateKey is the private key associated with the public key uploaded to your fiks-io/fiks-protokoll account
+                .WithAsiceSigningConfiguration(certificate2) // A X509Certificate2 certificate that also contains the private key
+                .BuildTestConfiguration();
+                
 );
 ```
 
@@ -185,7 +212,7 @@ Explanations:
 Here are examples using the two convenience methods.
 
 ```csharp
-// Prod config
+// Prod config with a asice X509Certificate2 certificate
 var config = FiksIOConfiguration.CreateProdConfiguration(
     integrasjonId: integrationId,
     integrasjonPassord: integrationPassord,


### PR DESCRIPTION
Asice signering er ikke optional lenger og det måtte inn som en sjekk i config builder.
Viser dette også i README