### PR TITLE
Maskinporten url endringer og forenklet/fikset FiksIOConfigurationBuilder

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 
@@ -27,6 +27,10 @@
       <None Remove="appsettings.json" />
       <Content Include="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+      <None Remove="appsettings.Development.json" />
+      <Content Include="appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>
 

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -28,10 +28,6 @@
       <Content Include="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
-      <None Remove="appsettings.Development.json" />
-      <Content Include="appsettings.Development.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
     </ItemGroup>
 
 </Project>

--- a/ExampleApplication/FiksIO/FiksIOConfigurationBuilder.cs
+++ b/ExampleApplication/FiksIO/FiksIOConfigurationBuilder.cs
@@ -10,7 +10,7 @@ namespace ExampleApplication.FiksIO
     public static class FiksIoConfigurationBuilder
     {
         
-        // Create configuration with the fluent builder
+        // Create a configuration for the test environment with the fluent builder
         public static FiksIOConfiguration CreateConfiguration(AppSettings appSettings)
         {
             var accountId = appSettings.FiksIOConfig.FiksIoAccountId;
@@ -22,8 +22,6 @@ namespace ExampleApplication.FiksIO
             var certPassword = appSettings.FiksIOConfig.MaskinPortenCompanyCertificatePassword;
             var asiceSigningPublicKey = appSettings.FiksIOConfig.AsiceSigningPublicKey;
             var asiceSigningPrivateKey = appSettings.FiksIOConfig.AsiceSigningPrivateKey;
-            var amqpHost = appSettings.FiksIOConfig.AmqpHost;
-            var amqpPort = appSettings.FiksIOConfig.AmqpPort;
             var apiHost = appSettings.FiksIOConfig.ApiHost;
             var apiPort = appSettings.FiksIOConfig.ApiPort;
                 
@@ -35,17 +33,18 @@ namespace ExampleApplication.FiksIO
                 .WithFiksIntegrasjonConfiguration(integrationId, integrationPassword)
                 .WithFiksKontoConfiguration(accountId, ReadFromFile(privateKeyPath))
                 .WithAsiceSigningConfiguration(asiceSigningPublicKey, asiceSigningPrivateKey)
-                .BuildConfiguration(amqpHost, apiHost, amqpPort, apiPort);
+                .WithApiConfiguration(apiHost, apiPort)
+                .BuildTestConfiguration();
         }
         
-        // Create a FiksIOConfiguration manually
+        // Create a FiksIOConfiguration manually. Use this if you want to use internal endpoints for testing, not Fiks-IO test or prod
         public static FiksIOConfiguration CreateConfig(string issuer, string p12Filename, string p12Password, string fiksIoAccountId,
             string fiksIoPrivateKeyPath, string integrasjonId, string integrasjonPassword)
         {
             // ID-porten machine to machine configuration
             var maskinportenConfig = new MaskinportenClientConfiguration(
-                audience: @"https://ver2.maskinporten.no/", // ID-porten audience path
-                tokenEndpoint: @"https://ver2.maskinporten.no/token", // ID-porten token path
+                audience: @"https://test.maskinporten.no/", // maskinporten audience path
+                tokenEndpoint: @"https://test.maskinporten.no/token", // maskinporten token path
                 issuer: issuer, // KS issuer name
                 numberOfSecondsLeftBeforeExpire: 10, // The token will be refreshed 10 seconds before it expires
                 certificate: new X509Certificate2(p12Filename, p12Password));

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
@@ -7,10 +7,10 @@ namespace KS.Fiks.IO.Client.Configuration
 {
     public class FiksIOConfiguration
     {
-        public const string maskinportenProdAudience = @"https://oidc.difi.no/idporten-oidc-provider/token";
-        public const string maskinportenProdTokenEndpoint = @"https://oidc.difi.no/idporten-oidc-provider/token";
-        public const string maskinportenTestAudience = @"https://oidc-ver2.difi.no/idporten-oidc-provider/";
-        public const string maskinportenTestTokenEndpoint = @"https://oidc-ver2.difi.no/idporten-oidc-provider/token";
+        public const string maskinportenProdAudience = @"https://maskinporten.no/";
+        public const string maskinportenProdTokenEndpoint = @"https://maskinporten.no/token";
+        public const string maskinportenTestAudience = @"https://test.maskinporten.no/";
+        public const string maskinportenTestTokenEndpoint = @"https://test.maskinporten.no/token";
         public const int maskinportenDefaultNumberOfSecondsLeftBeforeExpire = 10;
 
         public KontoConfiguration KontoConfiguration { get; }

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -72,7 +72,7 @@ namespace KS.Fiks.IO.Client.Configuration
                 asiceSigningConfiguration: _asiceSigningConfiguration,
                 integrasjonConfiguration: _integrasjonConfiguration,
                 kontoConfiguration: _kontoConfiguration,
-                maskinportenConfiguration: FiksIOConfiguration.CreateMaskinportenTestConfig(maskinportenIssuer, maskinportenCertificate));
+                maskinportenConfiguration: FiksIOConfiguration.CreateMaskinportenProdConfig(maskinportenIssuer, maskinportenCertificate));
         }
 
         public FiksIOConfigurationBuilder WithMaskinportenConfiguration(X509Certificate2 certificate, string issuer)
@@ -111,7 +111,7 @@ namespace KS.Fiks.IO.Client.Configuration
             _kontoConfiguration = new KontoConfiguration(fiksKontoId, fiksPrivateKey);
             return this;
         }
-        
+
         public FiksIOConfigurationBuilder WithFiksKontoConfiguration(Guid fiksKontoId, IEnumerable<string> fiksPrivateKeys)
         {
             _kontoConfiguration = new KontoConfiguration(fiksKontoId, fiksPrivateKeys);

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using Ks.Fiks.Maskinporten.Client;
 
 namespace KS.Fiks.IO.Client.Configuration
 {
@@ -11,6 +12,8 @@ namespace KS.Fiks.IO.Client.Configuration
         private IntegrasjonConfiguration _integrasjonConfiguration;
         private KontoConfiguration _kontoConfiguration;
         private AsiceSigningConfiguration _asiceSigningConfiguration;
+        private MaskinportenClientConfiguration _maskinportenClientConfiguration;
+        private ApiConfiguration _apiConfiguration;
         private bool ampqKeepAlive = true;
         private int ampqKeepAliveHealthCheckInterval = AmqpConfiguration.DefaultKeepAliveHealthCheckInterval;
         private string amqpApplicationName = string.Empty;
@@ -21,32 +24,6 @@ namespace KS.Fiks.IO.Client.Configuration
         public static FiksIOConfigurationBuilder Init()
         {
             return new FiksIOConfigurationBuilder();
-        }
-
-        public FiksIOConfiguration BuildConfiguration(string amqpHost, int amqpPort = 5671)
-        {
-            ValidateConfigurations();
-
-            return new FiksIOConfiguration(
-                amqpConfiguration: new AmqpConfiguration(amqpHost, amqpPort, applicationName: amqpApplicationName, prefetchCount: amqpPrefetchCount, keepAlive: ampqKeepAlive),
-                apiConfiguration: ApiConfiguration.CreateTestConfiguration(),
-                asiceSigningConfiguration: _asiceSigningConfiguration,
-                integrasjonConfiguration: _integrasjonConfiguration,
-                kontoConfiguration: _kontoConfiguration,
-                maskinportenConfiguration: FiksIOConfiguration.CreateMaskinportenTestConfig(maskinportenIssuer, maskinportenCertificate));
-        }
-
-        public FiksIOConfiguration BuildConfiguration(string amqpHost, string apiHost, int amqpPort = 5671, int apiPort = 443)
-        {
-            ValidateConfigurations();
-
-            return new FiksIOConfiguration(
-                amqpConfiguration: new AmqpConfiguration(amqpHost, amqpPort, applicationName: amqpApplicationName, prefetchCount: amqpPrefetchCount, keepAlive: ampqKeepAlive),
-                apiConfiguration: new ApiConfiguration(host: apiHost, port: apiPort),
-                asiceSigningConfiguration: _asiceSigningConfiguration,
-                integrasjonConfiguration: _integrasjonConfiguration,
-                kontoConfiguration: _kontoConfiguration,
-                maskinportenConfiguration: FiksIOConfiguration.CreateMaskinportenTestConfig(maskinportenIssuer, maskinportenCertificate));
         }
 
         public FiksIOConfiguration BuildTestConfiguration()
@@ -106,7 +83,7 @@ namespace KS.Fiks.IO.Client.Configuration
             return this;
         }
 
-        public FiksIOConfigurationBuilder WithFiksKontoConfiguration(Guid fiksKontoId, string fiksPrivateKey) 
+        public FiksIOConfigurationBuilder WithFiksKontoConfiguration(Guid fiksKontoId, string fiksPrivateKey)
         {
             _kontoConfiguration = new KontoConfiguration(fiksKontoId, fiksPrivateKey);
             return this;


### PR DESCRIPTION
I sammenheng med endringene til maskinporten (ver2 -> test) url så vi at url'ene her var av gammel type.
Nå er de endret til .maskinport.no.
Fikset også en bug i FiksIOConfigurationBuilder hvor det var låst til test-miljø for noen av build-metodene. Landet på at det trengs ikke å være så mye muligheter når man bruker fluent-builderen. Ønsker man å bruke noe annet enn test eller prod maskinporten, API eller AMQP så får man gjøre det på den manuelle måten. 
Fluent-builder bør være enkel å forstå og kommer med en Test eller Prod build metode man skal bruke.