### PR TITLE
Lagt til mulighet for å bygge en dev configuration via fluent builder

### DIFF
--- a/KS.Fiks.IO.Client/Configuration/ApiConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/ApiConfiguration.cs
@@ -5,7 +5,6 @@ namespace KS.Fiks.IO.Client.Configuration
         public const string ProdHost = "api.fiks.ks.no";
         public const string TestHost = "api.fiks.test.ks.no";
         private const string DefaultScheme = "https";
-
         private const int DefaultPort = 443;
 
         public ApiConfiguration(string scheme = null, string host = null, int? port = null)

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
@@ -117,5 +117,15 @@ namespace KS.Fiks.IO.Client.Configuration
                 numberOfSecondsLeftBeforeExpire: 10,
                 certificate: certificate);
         }
+
+        public static MaskinportenClientConfiguration CreateMaskinportenDevConfig(string audience, string tokenEndpoint, string issuer, X509Certificate2 certificate)
+        {
+            return new MaskinportenClientConfiguration(
+                audience: audience,
+                tokenEndpoint: tokenEndpoint,
+                issuer: issuer, // KS issuer name
+                numberOfSecondsLeftBeforeExpire: 10,
+                certificate: certificate);
+        }
     }
 }

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -52,6 +52,19 @@ namespace KS.Fiks.IO.Client.Configuration
                 maskinportenConfiguration: FiksIOConfiguration.CreateMaskinportenProdConfig(maskinportenIssuer, maskinportenCertificate));
         }
 
+        public FiksIOConfiguration BuildDevConfiguration(string amqpHost, string apiHost, string maskinportenAudience, string maskinportenTokenEndpoint)
+        {
+            ValidateConfigurations();
+
+            return new FiksIOConfiguration(
+                amqpConfiguration: new AmqpConfiguration(amqpHost, applicationName: amqpApplicationName, prefetchCount: amqpPrefetchCount, keepAlive: ampqKeepAlive),
+                apiConfiguration: new ApiConfiguration(host: apiHost),
+                asiceSigningConfiguration: _asiceSigningConfiguration,
+                integrasjonConfiguration: _integrasjonConfiguration,
+                kontoConfiguration: _kontoConfiguration,
+                maskinportenConfiguration: FiksIOConfiguration.CreateMaskinportenDevConfig(maskinportenAudience, maskinportenTokenEndpoint, maskinportenIssuer, maskinportenCertificate));
+        }
+
         public FiksIOConfigurationBuilder WithMaskinportenConfiguration(X509Certificate2 certificate, string issuer)
         {
             maskinportenIssuer = issuer;
@@ -101,11 +114,6 @@ namespace KS.Fiks.IO.Client.Configuration
             amqpApplicationName = applicationName;
             amqpPrefetchCount = prefetchCount;
             ampqKeepAliveHealthCheckInterval = keepAliveHealthCheckInterval;
-            return this;
-        }
-
-        public FiksIOConfigurationBuilder WithApiConfiguration(string hostName, int hostPort)
-        {
             return this;
         }
 


### PR DESCRIPTION
Oppdaget via arbeidet med å lage en arkiv-mock at det funket dårlig med annet enn test og prod når man bruker fluent builder. 

Kom fram til at det bør være mulig å sette apihost, amqphost og maskinporten url, men da som en dev configuration. 