### PR TITLE
RabbitMQ klient update for refresh av maskinporten token ved behov

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -28,10 +28,6 @@
       <Content Include="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
-      <None Remove="appsettings.Development.json" />
-      <Content Include="appsettings.Development.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
     </ItemGroup>
 
 </Project>

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -28,6 +28,10 @@
       <Content Include="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
+      <None Remove="appsettings.Development.json" />
+      <Content Include="appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
 </Project>

--- a/ExampleApplication/FiksIO/FiksIOConfigurationBuilder.cs
+++ b/ExampleApplication/FiksIO/FiksIOConfigurationBuilder.cs
@@ -28,7 +28,7 @@ namespace ExampleApplication.FiksIO
 
             return FiksIOConfigurationBuilder
                 .Init()
-                .WithAmqpConfiguration("fiks-io-client-dotnet-example-application", 1, true,20 * 1000)
+                .WithAmqpConfiguration("fiks-io-client-dotnet-example-application", 1)
                 .WithMaskinportenConfiguration(new X509Certificate2(certPath, certPassword), issuer)
                 .WithFiksIntegrasjonConfiguration(integrationId, integrationPassword)
                 .WithFiksKontoConfiguration(accountId, ReadFromFile(privateKeyPath))

--- a/ExampleApplication/Program.cs
+++ b/ExampleApplication/Program.cs
@@ -1,18 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using ExampleApplication.FiksIO;
 using KS.Fiks.IO.Client;
-using KS.Fiks.IO.Client.Amqp.RabbitMQ;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using RabbitMQ.Client.Logging;
 using Serilog;
 using Serilog.Events;
 using ILogger = Serilog.ILogger;
@@ -31,9 +26,9 @@ namespace ExampleApplication
      */
     class Program
     {
-        private static MessageSender messageSender;
-        private static Guid toAccountId;
-        private static ILogger Logger;
+        private static MessageSender _messageSender;
+        private static Guid _toAccountId;
+        private static ILogger _logger;
         public const string FiksIOPing = "ping";
         public const string FiksIOPong = "pong";
         public const string FiksArkivPing = "no.ks.fiks.arkiv.v1.ping";
@@ -56,12 +51,12 @@ namespace ExampleApplication
             var fiksIoClient = await FiksIOClient.CreateAsync(configuration, loggerFactory);
             
             // Creating messageSender as a local instance
-            messageSender = new MessageSender(fiksIoClient, appSettings);
+            _messageSender = new MessageSender(fiksIoClient, appSettings);
             
             // Setting the account to send messages to. In this case the same as sending account
-            toAccountId = appSettings.FiksIOConfig.FiksIoAccountId;
+            _toAccountId = appSettings.FiksIOConfig.FiksIoAccountId;
             
-            Logger = Log.ForContext(MethodBase.GetCurrentMethod()?.DeclaringType);
+            _logger = Log.ForContext(MethodBase.GetCurrentMethod()?.DeclaringType);
 
             var consoleKeyTask = Task.Run(() => { MonitorKeypress(); });
 
@@ -70,7 +65,7 @@ namespace ExampleApplication
                 {
                     configHost.AddEnvironmentVariables("DOTNET_");
                 })
-                .ConfigureServices((hostContext, services) =>
+                .ConfigureServices((_, services) =>
                 {
                     services.AddSingleton(appSettings);
                     services.AddSingleton(loggerFactory);
@@ -84,34 +79,37 @@ namespace ExampleApplication
 
         private static async Task MonitorKeypress()
         {
-            Logger.Information("Press Enter-key for sending a Fiks-IO 'ping' message");
-            Logger.Information("Press A-key for sending a Fiks-Arkiv V1 'ping' message");
-            Logger.Information("Press P-key for sending a Fiks-Plan V2 'ping' message");
-            Logger.Information("Press M-key for sending a Fiks-Matrikkelfoering V2 'ping' message");
-            
-            var cki = new ConsoleKeyInfo();
+            _logger.Information("Press Enter-key for sending a Fiks-IO 'ping' message");
+            _logger.Information("Press A-key for sending a Fiks-Arkiv V1 'ping' message");
+            _logger.Information("Press P-key for sending a Fiks-Plan V2 'ping' message");
+            _logger.Information("Press M-key for sending a Fiks-Matrikkelfoering V2 'ping' message");
+
+
+            ConsoleKeyInfo cki;
             do 
             {
+                //var cki = new ConsoleKeyInfo();
                 // true hides the pressed character from the console
                 cki = Console.ReadKey(true);
+
                 var key = cki.Key;
 
                 if (key == ConsoleKey.Enter)
                 {
-                    Logger.Information("Enter pressed. Sending Fiks-IO ping-message to account id: {ToAccountId}", toAccountId);
-                    var sendtMessageId = await messageSender.Send(FiksIOPing, toAccountId);
+                    _logger.Information("Enter pressed. Sending Fiks-IO ping-message to account id: {ToAccountId}", _toAccountId);
+                    await _messageSender.Send(FiksIOPing, _toAccountId);
                 } else if (key == ConsoleKey.A)
                 {
-                    Logger.Information("A-key pressed. Sending Fiks-Arkiv V1 ping-message to account id: {ToAccountId}", toAccountId);
-                    var sendtMessageId = await messageSender.Send(FiksArkivPing, toAccountId);
+                    _logger.Information("A-key pressed. Sending Fiks-Arkiv V1 ping-message to account id: {ToAccountId}", _toAccountId);
+                    await _messageSender.Send(FiksArkivPing, _toAccountId);
                 } else if (key == ConsoleKey.P)
                 {
-                    Logger.Information("P-key pressed. Sending Fiks-Plan V2 ping-message to account id: {ToAccountId}", toAccountId);
-                    var sendtMessageId = await messageSender.Send(FiksPlanPing, toAccountId);
+                    _logger.Information("P-key pressed. Sending Fiks-Plan V2 ping-message to account id: {ToAccountId}", _toAccountId);
+                    await _messageSender.Send(FiksPlanPing, _toAccountId);
                 } else if (key == ConsoleKey.M)
                 {
-                    Logger.Information("M-key pressed. Sending Fiks-Matrikkelfoering V2 ping-message to account id: {ToAccountId}", toAccountId);
-                    var sendtMessageId = await messageSender.Send(FiksMatrikkelfoeringPing, toAccountId);
+                    _logger.Information("M-key pressed. Sending Fiks-Matrikkelfoering V2 ping-message to account id: {ToAccountId}", _toAccountId);
+                    await _messageSender.Send(FiksMatrikkelfoeringPing, _toAccountId);
                 }
     
                 // Wait for an ESC
@@ -132,83 +130,5 @@ namespace ExampleApplication
 
             return LoggerFactory.Create(logging => logging.AddSerilog(logger));
         }
-    }
-    
-    class RabbitMqEventListener : EventListener
-    {
-        private const string EventSourceName = "rabbitmq-dotnet-client";
-        private readonly ILoggerFactory _loggerFactory;
-        private static ILogger<RabbitMqEventListener> _logger;
-        private readonly EventLevel _eventLevel;
-
-        public RabbitMqEventListener(ILoggerFactory loggerFactory, EventLevel eventLevel)
-        {
-            _loggerFactory = loggerFactory;
-            _eventLevel = eventLevel;
-            _logger = loggerFactory.CreateLogger<RabbitMqEventListener>();
-        }
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if(eventSource.Name == EventSourceName)
-            {
-                EnableEvents(eventSource, _eventLevel);
-            }
-        }
-
-        protected override void OnEventWritten(EventWrittenEventArgs eventData)
-        {
-            var message = $"EventLog from {EventSourceName} " +
-                          $", eventData.EventName: {eventData.EventName} " +
-                          $", eventData.TimeStamp: {eventData.TimeStamp} " +
-                          $", eventData.Message: {eventData.Message} " +
-                          $", eventData.Level: {eventData.Level} ";
-
-            var i = 0;
-            foreach (var payload in eventData.Payload)
-            {
-                if (payload is string)
-                {
-                    message += $", Message: {payload}";
-                }
-                else // Most likely this is a RabbitMQExceptionDetail as a Dictionary. Try to convert and write to message
-                {
-                    try
-                    {
-                        var payloadAsDictionary = ConvertObject<Dictionary<string, object>>(payload);
-                        if (payloadAsDictionary != null)
-                        {
-                            var rabbitMqExceptionDetail = new RabbitMqExceptionDetail(payloadAsDictionary);
-                            message += $", RabbitMqExceptionDetail message: {rabbitMqExceptionDetail.Message}, RabbitMqExceptionDetail stacktrace: {rabbitMqExceptionDetail.StackTrace}, RabbitMqExceptionDetail inner exception: {rabbitMqExceptionDetail.InnerException}, RabbitMqExceptionDetail type: {rabbitMqExceptionDetail.Type}";
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        //Do nothing
-                    }
-                }
-
-                i++;
-            }
-
-            if (eventData.Level.ToString().ToLower().Contains("err"))
-            {
-                _logger.LogError(message);
-            } else if (eventData.Level.ToString().ToLower().Contains("warn"))
-            {
-                _logger.LogWarning(message);
-            }
-            else
-            {
-                _logger.LogInformation(message);
-            }
-            
-        }
-
-        private static T ConvertObject<T>(object M) where T : class
-        {
-            var obj = JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(M));
-            return obj;
-        } 
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
@@ -21,18 +21,6 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         private Guid _integrationId = Guid.NewGuid();
         private string _integrationPassword = "defaultPassword";
 
-        public AmqpHandlerFixture()
-        {
-            ConnectionFactoryMock = new Mock<IConnectionFactory>();
-            ConnectionMock = new Mock<IConnection>();
-            ModelMock = new Mock<IModel>();
-            AmqpReceiveConsumerMock = new Mock<IAmqpReceiveConsumer>();
-            AmqpConsumerFactoryMock = new Mock<IAmqpConsumerFactory>();
-            MaskinportenClientMock = new Mock<IMaskinportenClient>();
-            SendHandlerMock = new Mock<ISendHandler>();
-            DokumentlagerHandlerMock = new Mock<IDokumentlagerHandler>();
-        }
-
         public AmqpHandlerFixture WhereConnectionfactoryThrowsException()
         {
             _connectionFactoryShouldThrow = true;
@@ -63,21 +51,21 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             return this;
         }
 
-        public Mock<IModel> ModelMock { get; }
+        public Mock<IModel> ModelMock { get; } = new Mock<IModel>();
 
-        public Mock<IConnectionFactory> ConnectionFactoryMock { get; }
+        public Mock<IConnectionFactory> ConnectionFactoryMock { get; } = new Mock<IConnectionFactory>();
 
-        public Mock<IConnection> ConnectionMock { get; }
+        public Mock<IConnection> ConnectionMock { get; } = new Mock<IConnection>();
 
-        internal Mock<IAmqpConsumerFactory> AmqpConsumerFactoryMock { get; }
+        internal Mock<IAmqpConsumerFactory> AmqpConsumerFactoryMock { get; } = new Mock<IAmqpConsumerFactory>();
 
-        internal Mock<IAmqpReceiveConsumer> AmqpReceiveConsumerMock { get; }
+        internal Mock<IAmqpReceiveConsumer> AmqpReceiveConsumerMock { get; } = new Mock<IAmqpReceiveConsumer>();
 
-        internal Mock<IMaskinportenClient> MaskinportenClientMock { get; }
+        internal Mock<IMaskinportenClient> MaskinportenClientMock { get; } = new Mock<IMaskinportenClient>();
 
-        internal Mock<IDokumentlagerHandler> DokumentlagerHandlerMock { get; }
+        internal Mock<IDokumentlagerHandler> DokumentlagerHandlerMock { get; } = new Mock<IDokumentlagerHandler>();
 
-        internal Mock<ISendHandler> SendHandlerMock { get; }
+        internal Mock<ISendHandler> SendHandlerMock { get; } = new Mock<ISendHandler>();
 
         internal IAmqpHandler CreateSut()
         {

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
@@ -6,7 +6,6 @@ using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Client.Dokumentlager;
 using KS.Fiks.IO.Client.Send;
 using Ks.Fiks.Maskinporten.Client;
-using Microsoft.Extensions.Logging;
 using Moq;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Exceptions;

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
@@ -81,16 +81,5 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             _fixture.AmqpReceiveConsumerMock.Raise(_ => _.ConsumerCancelled += null, this, null);
             counter.Should().Be(1);
         }
-
-        /*
-        [Fact]
-        public void PasswordIsSetToIntegrationPasswordAndMaskinportenToken()
-        {
-            var password = "myIntegrationPassword";
-            var token = "maskinportenExpectedToken";
-            var sut = _fixture.WithMaskinportenToken(token).WithIntegrationPassword(password).CreateSut();
-            _fixture.ConnectionFactoryMock.VerifySet(_ => _.Password = $"{password} {token}");
-        }
-        */
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
@@ -82,13 +82,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             counter.Should().Be(1);
         }
 
-        [Fact]
-        public void GetsTokenFromMaskinportenWhenCreated()
-        {
-            var sut = _fixture.CreateSut();
-            _fixture.MaskinportenClientMock.Verify(_ => _.GetAccessToken(It.IsAny<string>()));
-        }
-
+        /*
         [Fact]
         public void PasswordIsSetToIntegrationPasswordAndMaskinportenToken()
         {
@@ -97,13 +91,6 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             var sut = _fixture.WithMaskinportenToken(token).WithIntegrationPassword(password).CreateSut();
             _fixture.ConnectionFactoryMock.VerifySet(_ => _.Password = $"{password} {token}");
         }
-
-        [Fact]
-        public void UserNameIsSetToIntegrationId()
-        {
-            var id = Guid.NewGuid();
-            var sut = _fixture.WithIntegrationId(id).CreateSut();
-            _fixture.ConnectionFactoryMock.VerifySet(_ => _.UserName = id.ToString());
-        }
+        */
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderFixture.cs
@@ -1,0 +1,58 @@
+using System;
+using KS.Fiks.IO.Client.Amqp;
+using KS.Fiks.IO.Client.Configuration;
+using Ks.Fiks.Maskinporten.Client;
+using Moq;
+
+namespace KS.Fiks.IO.Client.Tests.Amqp
+{
+    public class MaskinportenCredentialsProviderFixture
+    {
+        private bool _connectionFactoryShouldThrow;
+        private bool _connectionShouldThrow;
+        private string _firstToken = "firsttesttoken";
+        private Guid _integrationId = Guid.NewGuid();
+        private string _integrationPassword = "defaultPassword";
+        private int _expiresIn = 100;
+
+        internal Mock<IMaskinportenClient> MaskinportenClientMock { get; } = new Mock<IMaskinportenClient>();
+
+        internal MaskinportenCredentialsProvider CreateSut()
+        {
+            var conf = new IntegrasjonConfiguration(_integrationId, _integrationPassword);
+            SetupMocks();
+            var credentialsProvider = new MaskinportenCredentialsProvider("Test", MaskinportenClientMock.Object, conf);
+
+            return credentialsProvider;
+        }
+
+        private void SetupMocks()
+        {
+            MaskinportenClientMock.Setup(_ => _.GetAccessToken(It.IsAny<string>()))
+                                  .ReturnsAsync(new MaskinportenToken(_firstToken, _expiresIn));
+        }
+
+        private IntegrasjonConfiguration CreateIntegrationConfiguration()
+        {
+            return new IntegrasjonConfiguration(_integrationId, _integrationPassword);
+        }
+
+        public MaskinportenCredentialsProviderFixture WithMaskinportenToken(string token)
+        {
+            _firstToken = token;
+            return this;
+        }
+
+        public MaskinportenCredentialsProviderFixture WithIntegrationPassword(string password)
+        {
+            _integrationPassword = password;
+            return this;
+        }
+
+        public MaskinportenCredentialsProviderFixture WithTokenExpiresIn(int expiresIn)
+        {
+            _expiresIn = expiresIn;
+            return this;
+        }
+    }
+}

--- a/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+
+namespace KS.Fiks.IO.Client.Tests.Amqp
+{
+    public class MaskinportenCredentialsProviderTests
+    {
+        private readonly MaskinportenCredentialsProviderFixture _fixture;
+
+        public MaskinportenCredentialsProviderTests()
+        {
+            _fixture = new MaskinportenCredentialsProviderFixture();
+        }
+
+        [Fact]
+        public void PasswordIsSetToIntegrationPasswordAndMaskinportenToken()
+        {
+            var password = "myIntegrationPassword";
+            var token = "maskinportenExpectedToken";
+            var sut = _fixture.WithMaskinportenToken(token).WithIntegrationPassword(password).CreateSut();
+            Assert.Equal($"{password} {token}", sut.Password);
+        }
+    }
+}

--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
@@ -32,7 +32,6 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
             config.AmqpConfiguration.Host.Should().Be("io.fiks.ks.no");
-            config.AmqpConfiguration.KeepAlive.Should().BeFalse();
             config.ApiConfiguration.Host.Should().Be("api.fiks.ks.no");
         }
 
@@ -55,13 +54,11 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 privatNokkel: privatNokkel,
                 issuer: issuer,
                 maskinportenSertifikat: maskinportenSertifikat,
-                asiceSertifikat: asiceSertifikat,
-                keepAlive: true);
+                asiceSertifikat: asiceSertifikat);
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
             config.AmqpConfiguration.Host.Should().Be("io.fiks.ks.no");
-            config.AmqpConfiguration.KeepAlive.Should().BeTrue();
             config.ApiConfiguration.Host.Should().Be("api.fiks.ks.no");
         }
 
@@ -90,7 +87,6 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
             config.AmqpConfiguration.Host.Should().Be("io.fiks.test.ks.no");
-            config.AmqpConfiguration.KeepAlive.Should().BeFalse();
             config.ApiConfiguration.Host.Should().Be("api.fiks.test.ks.no");
         }
 
@@ -113,14 +109,12 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 privatNokkel: privatNokkel,
                 issuer: issuer,
                 maskinportenSertifikat: maskinportenSertifikat,
-                asiceSertifikat: asiceSertifikat,
-                keepAlive: true
+                asiceSertifikat: asiceSertifikat
             );
 
             config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
             config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
             config.AmqpConfiguration.Host.Should().Be("io.fiks.test.ks.no");
-            config.AmqpConfiguration.KeepAlive.Should().BeTrue();
             config.ApiConfiguration.Host.Should().Be("api.fiks.test.ks.no");
         }
     }

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -14,11 +14,11 @@
         <CodeAnalysisRuleSet>..\fiks.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="KS.Fiks.ASiC-E" Version="2.0.0" />
         <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.9" />
-        <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.7" />
+        <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.8-build.20231024131927916" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1">
           <PrivateAssets>all</PrivateAssets>
@@ -26,8 +26,9 @@
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
-        <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
-        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
+        <PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
+++ b/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Configuration;
 using Ks.Fiks.Maskinporten.Client;
 using Microsoft.Extensions.Logging;
@@ -75,8 +76,10 @@ namespace KS.Fiks.IO.Client.Amqp
 
         private MaskinportenToken RequestOrRenewToken()
         {
-             _maskinportenToken = _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope).Result;
-             ValidUntil = DateTime.Now.TimeOfDay.Add(TimeSpan.FromSeconds(_maskinportenToken.ExpiresIn - ValidUntilBufferInSeconds));
+            var getAccessTokenTask = Task.Run(() => _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope));
+            getAccessTokenTask.Wait();
+            _maskinportenToken = getAccessTokenTask.Result;
+            ValidUntil = DateTime.Now.TimeOfDay.Add(TimeSpan.FromSeconds(_maskinportenToken.ExpiresIn - ValidUntilBufferInSeconds));
             return _maskinportenToken;
         }
     }

--- a/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
+++ b/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using KS.Fiks.IO.Client.Configuration;
+using Ks.Fiks.Maskinporten.Client;
+using RabbitMQ.Client;
+using RabbitMQ.Client.OAuth2;
+
+namespace KS.Fiks.IO.Client.Amqp
+{
+    public class Token : IToken
+    {
+        private readonly JsonToken _source;
+        private readonly DateTime _lastTokenRenewal;
+
+        public Token(JsonToken json)
+        {
+            this._source = json;
+            this._lastTokenRenewal = DateTime.Now;
+        }
+
+        public string AccessToken
+        {
+            get
+            {
+                return _source.access_token;
+            }
+        }
+
+        public string RefreshToken
+        {
+            get
+            {
+                return _source.refresh_token;
+            }
+        }
+
+        public TimeSpan ExpiresIn
+        {
+            get
+            {
+                return TimeSpan.FromSeconds(_source.expires_in);
+            }
+        }
+
+        bool IToken.hasExpired
+        {
+            get
+            {
+                TimeSpan age = DateTime.Now - _lastTokenRenewal;
+                return age > ExpiresIn;
+            }
+        }
+    }
+    
+    public class MaskinportenCredentialsProvider : ICredentialsProvider
+    {
+        const int TOKEN_RETRIEVAL_TIMEOUT = 5000;
+        private ReaderWriterLock _lock = new ReaderWriterLock();
+        private IMaskinportenClient _maskinportenClient;
+        private IntegrasjonConfiguration _integrasjonConfiguration;
+        private MaskinportenToken _maskinportenToken;
+
+        public MaskinportenCredentialsProvider(IMaskinportenClient maskinportenClient, IntegrasjonConfiguration integrasjonConfiguration)
+        {
+            _maskinportenClient = maskinportenClient;
+            _integrasjonConfiguration = integrasjonConfiguration;
+        }
+
+        public string Name { get; }
+
+        public string UserName => _integrasjonConfiguration.IntegrasjonId.ToString();
+
+        public string Password => $"{_integrasjonConfiguration.IntegrasjonPassord} {checkState().Token}";
+
+        public TimeSpan? ValidUntil
+        {
+            get
+            {
+                var t = checkState();
+                if (t is null)
+                {
+                    return null;
+                }
+
+                return TimeSpan.FromSeconds(t.ExpiresIn);
+            }
+        }
+
+        public void Refresh()
+        {
+            retrieveToken();
+        }
+
+        private MaskinportenToken checkState()
+        {
+            _lock.AcquireReaderLock(TOKEN_RETRIEVAL_TIMEOUT);
+            try
+            {
+                if (_maskinportenToken != null)
+                {
+                    return _maskinportenToken;
+                }
+            }
+            finally
+            {
+                _lock.ReleaseReaderLock();
+            }
+
+            return retrieveToken();
+        }
+
+        private MaskinportenToken retrieveToken()
+        {
+            _lock.AcquireWriterLock(TOKEN_RETRIEVAL_TIMEOUT);
+            try
+            {
+                return requestOrRenewToken();
+            }
+            finally
+            {
+                _lock.ReleaseReaderLock();
+            }
+        }
+
+        private MaskinportenToken requestOrRenewToken()
+        {
+            return _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope).Result;
+        }
+    }
+}

--- a/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
+++ b/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using RabbitMQ.Client.Logging;
+
+namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
+{
+    public class RabbitMQEventLogger : EventListener
+    {
+        private const string EventSourceName = "rabbitmq-dotnet-client";
+        private static ILogger<RabbitMQEventLogger> _logger;
+        private readonly EventLevel _eventLevel;
+
+        public RabbitMQEventLogger(ILoggerFactory loggerFactory, EventLevel eventLevel)
+        {
+            _eventLevel = eventLevel;
+            _logger = loggerFactory.CreateLogger<RabbitMQEventLogger>();
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if(eventSource.Name == EventSourceName)
+            {
+                EnableEvents(eventSource, _eventLevel);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            var message = $"EventLog from {EventSourceName} " +
+                          $", eventData.Level: {eventData.Level} ";
+
+            var i = 0;
+            foreach (var payload in eventData.Payload)
+            {
+                if (payload is string)
+                {
+                    message += $", Message: {payload}";
+                }
+                else
+                {
+                    try
+                    {
+                        var payloadAsDictionary = ConvertObject<Dictionary<string, object>>(payload);
+                        if (payloadAsDictionary != null)
+                        {
+                            var rabbitMqExceptionDetail = new RabbitMqExceptionDetail(payloadAsDictionary);
+                            message += $", RabbitMqExceptionDetail message: {rabbitMqExceptionDetail.Message}, RabbitMqExceptionDetail stacktrace: {rabbitMqExceptionDetail.StackTrace}, RabbitMqExceptionDetail inner exception: {rabbitMqExceptionDetail.InnerException}, RabbitMqExceptionDetail type: {rabbitMqExceptionDetail.Type}";
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        //Do nothing
+                    }
+                }
+
+                i++;
+            }
+
+            if (eventData.Level.ToString().ToLower().Contains("err"))
+            {
+                _logger.LogError(message);
+            } else if (eventData.Level.ToString().ToLower().Contains("warn"))
+            {
+                _logger.LogWarning(message);
+            }
+            else
+            {
+                _logger.LogInformation(message);
+            }
+        }
+
+        private static T ConvertObject<T>(object m)
+            where T : class
+        {
+            var obj = JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(m));
+            return obj;
+        }
+    }
+}

--- a/KS.Fiks.IO.Client/Configuration/AmqpConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/AmqpConfiguration.cs
@@ -9,7 +9,7 @@ namespace KS.Fiks.IO.Client.Configuration
         public const string TestHost = "io.fiks.test.ks.no";
         public const int DefaultKeepAliveHealthCheckInterval = 1 * 60 * 1000;
 
-        public AmqpConfiguration(string host, int port = 5671, SslOption sslOption = null, string applicationName = "Fiks IO klient (dotnet)", ushort prefetchCount = 10, bool keepAlive = true, int keepAliveCheckInterval = DefaultKeepAliveHealthCheckInterval)
+        public AmqpConfiguration(string host, int port = 5671, SslOption sslOption = null, string applicationName = "Fiks IO klient (dotnet)", ushort prefetchCount = 10)
         {
             Host = host;
             Port = port;
@@ -21,8 +21,6 @@ namespace KS.Fiks.IO.Client.Configuration
             };
             ApplicationName = applicationName;
             PrefetchCount = prefetchCount;
-            KeepAlive = keepAlive;
-            KeepAliveHealthCheckInterval = keepAliveCheckInterval;
         }
 
         public string Host { get; }
@@ -41,18 +39,14 @@ namespace KS.Fiks.IO.Client.Configuration
          */
         public ushort PrefetchCount { get; }
 
-        public bool KeepAlive { get; }
-
-        public int KeepAliveHealthCheckInterval { get; }
-
-        public static AmqpConfiguration CreateProdConfiguration(bool keepAlive = false, string applicationName = null)
+        public static AmqpConfiguration CreateProdConfiguration(string applicationName = null)
         {
-            return new AmqpConfiguration(ProdHost, keepAlive: keepAlive, applicationName: applicationName);
+            return new AmqpConfiguration(ProdHost, applicationName: applicationName);
         }
 
-        public static AmqpConfiguration CreateTestConfiguration(bool keepAlive = false, string applicationName = null)
+        public static AmqpConfiguration CreateTestConfiguration(string applicationName = null)
         {
-            return new AmqpConfiguration(TestHost, keepAlive: keepAlive, applicationName: applicationName);
+            return new AmqpConfiguration(TestHost, applicationName: applicationName);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Configuration/AmqpConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/AmqpConfiguration.cs
@@ -7,7 +7,6 @@ namespace KS.Fiks.IO.Client.Configuration
     {
         public const string ProdHost = "io.fiks.ks.no";
         public const string TestHost = "io.fiks.test.ks.no";
-        public const int DefaultKeepAliveHealthCheckInterval = 1 * 60 * 1000;
 
         public AmqpConfiguration(string host, int port = 5671, SslOption sslOption = null, string applicationName = "Fiks IO klient (dotnet)", ushort prefetchCount = 10)
         {

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
@@ -66,11 +66,10 @@ namespace KS.Fiks.IO.Client.Configuration
             string issuer,
             X509Certificate2 maskinportenSertifikat,
             X509Certificate2 asiceSertifikat,
-            bool keepAlive = false,
             string applicationName = null)
         {
             return new FiksIOConfiguration(
-                amqpConfiguration: AmqpConfiguration.CreateProdConfiguration(keepAlive, applicationName),
+                amqpConfiguration: AmqpConfiguration.CreateProdConfiguration(applicationName),
                 apiConfiguration: ApiConfiguration.CreateProdConfiguration(),
                 integrasjonConfiguration: new IntegrasjonConfiguration(integrasjonId, integrasjonPassord),
                 kontoConfiguration: new KontoConfiguration(kontoId, privatNokkel),
@@ -86,11 +85,10 @@ namespace KS.Fiks.IO.Client.Configuration
             string issuer,
             X509Certificate2 maskinportenSertifikat,
             X509Certificate2 asiceSertifikat,
-            bool keepAlive = false,
             string applicationName = null)
         {
             return new FiksIOConfiguration(
-                amqpConfiguration: AmqpConfiguration.CreateTestConfiguration(keepAlive, applicationName),
+                amqpConfiguration: AmqpConfiguration.CreateTestConfiguration(applicationName),
                 apiConfiguration: ApiConfiguration.CreateTestConfiguration(),
                 integrasjonConfiguration: new IntegrasjonConfiguration(fiksIntegrasjonId, fiksIntegrasjonPassord),
                 kontoConfiguration: new KontoConfiguration(fiksKontoId, privatNokkel),

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
@@ -11,7 +11,6 @@ namespace KS.Fiks.IO.Client.Configuration
         public const string maskinportenProdTokenEndpoint = @"https://maskinporten.no/token";
         public const string maskinportenTestAudience = @"https://test.maskinporten.no/";
         public const string maskinportenTestTokenEndpoint = @"https://test.maskinporten.no/token";
-        public const int maskinportenDefaultNumberOfSecondsLeftBeforeExpire = 10;
 
         public KontoConfiguration KontoConfiguration { get; }
 

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfigurationBuilder.cs
@@ -14,8 +14,6 @@ namespace KS.Fiks.IO.Client.Configuration
         private AsiceSigningConfiguration _asiceSigningConfiguration;
         private MaskinportenClientConfiguration _maskinportenClientConfiguration;
         private ApiConfiguration _apiConfiguration;
-        private bool ampqKeepAlive = true;
-        private int ampqKeepAliveHealthCheckInterval = AmqpConfiguration.DefaultKeepAliveHealthCheckInterval;
         private string amqpApplicationName = string.Empty;
         private ushort amqpPrefetchCount = 10;
         private string maskinportenIssuer = string.Empty;
@@ -31,7 +29,7 @@ namespace KS.Fiks.IO.Client.Configuration
             ValidateConfigurations();
 
             return new FiksIOConfiguration(
-                amqpConfiguration: new AmqpConfiguration(AmqpConfiguration.TestHost, applicationName: amqpApplicationName, prefetchCount: amqpPrefetchCount, keepAlive: ampqKeepAlive, keepAliveCheckInterval: ampqKeepAliveHealthCheckInterval),
+                amqpConfiguration: new AmqpConfiguration(AmqpConfiguration.TestHost, applicationName: amqpApplicationName, prefetchCount: amqpPrefetchCount),
                 apiConfiguration: ApiConfiguration.CreateTestConfiguration(),
                 asiceSigningConfiguration: _asiceSigningConfiguration,
                 integrasjonConfiguration: _integrasjonConfiguration,
@@ -44,7 +42,7 @@ namespace KS.Fiks.IO.Client.Configuration
             ValidateConfigurations();
 
             return new FiksIOConfiguration(
-                amqpConfiguration: new AmqpConfiguration(AmqpConfiguration.ProdHost, applicationName: amqpApplicationName, prefetchCount: amqpPrefetchCount, keepAlive: ampqKeepAlive),
+                amqpConfiguration: new AmqpConfiguration(AmqpConfiguration.ProdHost, applicationName: amqpApplicationName, prefetchCount: amqpPrefetchCount),
                 apiConfiguration: ApiConfiguration.CreateProdConfiguration(),
                 asiceSigningConfiguration: _asiceSigningConfiguration,
                 integrasjonConfiguration: _integrasjonConfiguration,
@@ -95,12 +93,10 @@ namespace KS.Fiks.IO.Client.Configuration
             return this;
         }
 
-        public FiksIOConfigurationBuilder WithAmqpConfiguration(string applicationName, ushort prefetchCount, bool keepAlive = true, int keepAliveHealthCheckInterval = AmqpConfiguration.DefaultKeepAliveHealthCheckInterval)
+        public FiksIOConfigurationBuilder WithAmqpConfiguration(string applicationName, ushort prefetchCount)
         {
-            ampqKeepAlive = keepAlive;
             amqpApplicationName = applicationName;
             amqpPrefetchCount = prefetchCount;
-            ampqKeepAliveHealthCheckInterval = keepAliveHealthCheckInterval;
             return this;
         }
 

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -12,12 +12,12 @@
 		<RepositoryUrl>https://github.com/ks-no/fiks-io-client-dotnet.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>FIKS</PackageTags>
-		<VersionPrefix>3.0.9</VersionPrefix>
+		<VersionPrefix>4.0.0</VersionPrefix>
 		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<AssemblyVersion>3.0.0.0</AssemblyVersion>
-		<FileVersion>3.0.0.0</FileVersion>
+		<AssemblyVersion>4.0.0.0</AssemblyVersion>
+		<FileVersion>4.0.0.0</FileVersion>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>../fiks-io-strongly-named-key.snk</AssemblyOriginatorKeyFile>

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -47,7 +47,7 @@
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.11" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
+		<PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -45,11 +45,12 @@
 		<PackageReference Include="KS.Fiks.ASiC-E" Version="2.0.0" />
 		<PackageReference Include="KS.Fiks.Crypto" Version="2.0.0" />
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.9" />
-		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.7" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.8-build.20231024131927916" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+		<PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+		<PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Den siste versjonen av RabbitMQ klienten gir oss mulighet for å hente nytt token ved behov. 

Har også laget en RabbitMQEventLogger som logger ut EventLogger for RabbitMQ klienten. Dette gjør at man nå kan se feil osv fra RabbitMQ klienten.

Dette blir en breaking change