### PR TITLE
Tatt bort RabbitMQEventLogger fra AMQPHandler og filtrerer bor det som ikke skal logges

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -28,10 +28,6 @@
       <Content Include="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
-      <None Remove="appsettings.Development.json" />
-      <Content Include="appsettings.Development.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
     </ItemGroup>
 
 </Project>

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -28,6 +28,10 @@
       <Content Include="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
+      <None Remove="appsettings.Development.json" />
+      <Content Include="appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
 </Project>

--- a/ExampleApplication/Program.cs
+++ b/ExampleApplication/Program.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics.Tracing;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using ExampleApplication.FiksIO;
 using KS.Fiks.IO.Client;
+using KS.Fiks.IO.Client.Amqp.RabbitMQ;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -37,6 +39,7 @@ namespace ExampleApplication
         public const string FiksPlanPong = "no.ks.fiks.plan.v2.pong";
         public const string FiksMatrikkelfoeringPing = "no.ks.fiks.matrikkelfoering.v2.ping";
         public const string FiksMatrikkelfoeringPong = "no.ks.fiks.matrikkelfoering.v2.pong";
+        private static RabbitMQEventLogger _rabbitMqEventLogger;
         
         public static async Task Main(string[] args)
         {
@@ -49,6 +52,7 @@ namespace ExampleApplication
             var appSettings = AppSettingsBuilder.CreateAppSettings(configurationRoot);
             var configuration = FiksIoConfigurationBuilder.CreateConfiguration(appSettings);
             var fiksIoClient = await FiksIOClient.CreateAsync(configuration, loggerFactory);
+            _rabbitMqEventLogger = new RabbitMQEventLogger(loggerFactory, EventLevel.Informational);
             
             // Creating messageSender as a local instance
             _messageSender = new MessageSender(fiksIoClient, appSettings);

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
-using KS.Fiks.IO.Client.Amqp.RabbitMQ;
 using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Client.Dokumentlager;
 using KS.Fiks.IO.Client.Exceptions;
@@ -26,7 +24,6 @@ namespace KS.Fiks.IO.Client.Amqp
         private IConnection _connection;
         private IModel _channel;
         private IAmqpReceiveConsumer _receiveConsumer;
-        private RabbitMQEventLogger _rabbitMqEventLogger;
 
         private AmqpHandler(
             IMaskinportenClient maskinportenClient,
@@ -51,7 +48,6 @@ namespace KS.Fiks.IO.Client.Amqp
             if (loggerFactory != null)
             {
                 _logger = loggerFactory.CreateLogger<AmqpHandler>();
-                _rabbitMqEventLogger = new RabbitMQEventLogger(loggerFactory, EventLevel.Warning);
             }
         }
 
@@ -107,7 +103,6 @@ namespace KS.Fiks.IO.Client.Amqp
             {
                 _channel.Dispose();
                 _connection.Dispose();
-                _rabbitMqEventLogger?.Dispose();
             }
         }
 

--- a/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
+++ b/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
@@ -21,8 +21,7 @@ namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            base.OnEventSourceCreated(eventSource);
-            if (eventSource.Name == EventSourceName)
+            if(eventSource.Name.Equals(EventSourceName))
             {
                 EnableEvents(eventSource, _eventLevel);
             }
@@ -30,7 +29,7 @@ namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            var message = $"EventLog from {eventData.EventSource} " +
+            var message = $"EventLog from {eventData.EventSource.Name}  " +
                           $", eventData.Level: {eventData.Level}, eventData.Message: {eventData.Message}";
 
             var i = 0;

--- a/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
+++ b/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
@@ -29,7 +29,7 @@ namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            var message = $"EventLog from {EventSourceName} " +
+            var message = $"EventLog from {eventData.EventSource} " +
                           $", eventData.Level: {eventData.Level}, eventData.Message: {eventData.Message}";
 
             var i = 0;

--- a/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
+++ b/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
@@ -21,7 +21,8 @@ namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            if(eventSource.Name == EventSourceName)
+            base.OnEventSourceCreated(eventSource);
+            if (eventSource.Name == EventSourceName)
             {
                 EnableEvents(eventSource, _eventLevel);
             }

--- a/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
+++ b/KS.Fiks.IO.Client/Amqp/RabbitMQ/RabbitMQEventLogger.cs
@@ -9,7 +9,7 @@ namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
 {
     public class RabbitMQEventLogger : EventListener
     {
-        private const string EventSourceName = "rabbitmq-dotnet-client";
+        private const string RabbitMQEventSourceName = "rabbitmq-dotnet-client";
         private static ILogger<RabbitMQEventLogger> _logger;
         private readonly EventLevel _eventLevel;
 
@@ -21,7 +21,7 @@ namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            if(eventSource.Name.Equals(EventSourceName))
+            if(eventSource.Name.Equals(RabbitMQEventSourceName))
             {
                 EnableEvents(eventSource, _eventLevel);
             }
@@ -29,6 +29,11 @@ namespace KS.Fiks.IO.Client.Amqp.RabbitMQ
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
+            if (eventData.EventSource.Name != RabbitMQEventSourceName)
+            {
+                return;
+            }
+
             var message = $"EventLog from {eventData.EventSource.Name}  " +
                           $", eventData.Level: {eventData.Level}, eventData.Message: {eventData.Message}";
 


### PR DESCRIPTION
Nå må den som konsumerer Fiks-IO klienten velge selv om man ønsker å bruke RabbitMQEventLogger.
Det ble feil å gjøre det i klienten da man kan ha flere klienter i samme applikasjon. Det bør være en listener pr applikasjon. 

Vi klarte foreløpig ikke å finne ut hvorfor OnEventWritten får inn andre events enn den vi registrerte, så vi filtrerte nå bort alt annet enn det som er RabbitMQ som kilde. 
Dette bør vi forsøke å finne ut av, men foreløpig får vi gjøre det på denne måten.