### PR TITLE
Flyttet Dispose() til etter unsubscribe

### DIFF
--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -130,13 +130,13 @@ namespace KS.Fiks.IO.Client.Amqp
                 _receiveConsumer.ConsumerCancelled -= _cancelledEvent;
             }
 
-            _channel.Dispose();
-            _connection.Dispose();
-
             // Unsubscribe events for logging of RabbitMQ events
             _connection.ConnectionShutdown -= _amqpWatcher.HandleConnectionShutdown;
             _connection.ConnectionBlocked -= _amqpWatcher.HandleConnectionBlocked;
             _connection.ConnectionUnblocked -= _amqpWatcher.HandleConnectionUnblocked;
+
+            _channel.Dispose();
+            _connection.Dispose();
         }
 
         private Task Connect(AmqpConfiguration amqpConfiguration)
@@ -148,6 +148,7 @@ namespace KS.Fiks.IO.Client.Amqp
             _connection.ConnectionShutdown += _amqpWatcher.HandleConnectionShutdown;
             _connection.ConnectionBlocked += _amqpWatcher.HandleConnectionBlocked;
             _connection.ConnectionUnblocked += _amqpWatcher.HandleConnectionUnblocked;
+
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Rapportert feil fra Visma. 
Dispose() ble gjort før unsubscribe på objektet som ble disposet og førte naturligvis til krasj.