### PR TITLE
Henter antall konsumenter ved lookup og lagt til status metode

### DIFF
--- a/ExampleApplication/FiksIO/FiksIOSubscriber.cs
+++ b/ExampleApplication/FiksIO/FiksIOSubscriber.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,11 +13,9 @@ namespace ExampleApplication.FiksIO
 {
     public class FiksIOSubscriber : BackgroundService
     {
-        private IFiksIOClient _fiksIoClient;
+        private readonly IFiksIOClient _fiksIoClient;
         private readonly AppSettings _appSettings;
         private static readonly ILogger Log = Serilog.Log.ForContext(MethodBase.GetCurrentMethod()?.DeclaringType);
-        private Timer FiksIoClientStatusCheckTimer { get; set; }
-        private const int HealthCheckInterval = 15 * 1000;
 
         public FiksIOSubscriber(IFiksIOClient fiksIoClient, AppSettings appSettings)
         {
@@ -30,11 +26,12 @@ namespace ExampleApplication.FiksIO
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             Log.Information("FiksIOSubscriber - Application is starting subscribe");
-            FiksIoClientStatusCheckTimer = new Timer(WriteStatusToLog, null, HealthCheckInterval, HealthCheckInterval);
+            
             SubscribeToFiksIOClient();
+
             await Task.CompletedTask;
         }
-    
+
         private async void OnReceivedMelding(object sender, MottattMeldingArgs mottatt)
         {
             var receivedMeldingType = mottatt.Melding.MeldingType;
@@ -116,35 +113,11 @@ namespace ExampleApplication.FiksIO
             return payloadTxt;
         }
 
-        private void SubscribeToFiksIOClient()
+        public void SubscribeToFiksIOClient()
         {
             var accountId = _appSettings.FiksIOConfig.FiksIoAccountId;
             Log.Information($"FiksIOSubscriber - Starting FiksIOReceiveAndReplySubscriber subscribe on account {accountId}...");
             _fiksIoClient.NewSubscription(OnReceivedMelding);
-        }
-        
-        private void WriteStatusToLog(object o)
-        {
-            Log.Information($"FiksIOSubscriber status check - FiksIOClient connection IsOpen status: {_fiksIoClient.IsOpen()}");
-            Log.Information($"FiksIOSubscriber status check - Maskinporten reachable : {CheckMaskinportenIsReachable()}");
-        }
-
-        private bool CheckMaskinportenIsReachable()
-        {
-            var request = (HttpWebRequest) WebRequest.Create(_appSettings.FiksIOConfig.MaskinPortenAudienceUrl);
-            request.Timeout = 5 * 1000;
-            request.Method = "HEAD";
-            try
-            {
-                using (HttpWebResponse response = (HttpWebResponse) request.GetResponse())
-                {
-                    return response.StatusCode == HttpStatusCode.OK;
-                }
-            }
-            catch (WebException)
-            {
-                return false;
-            }
         }
     }
 }

--- a/ExampleApplication/README.md
+++ b/ExampleApplication/README.md
@@ -12,12 +12,14 @@ The application listens to different keys for different types of ping-messages. 
 - A-key - Fiks-Arkiv protocol 'ping'-message
 - P-key - Fiks-Plan protocol 'ping'-message
 - M-key - Fiks-Matrikkelfoering protocol 'ping'-message
+- L-key - Write log with: IsOpen(), Maskinporten reachable and result from the status of the account from Fiks-IO rest-services 
+
+The L-key will write status of the _IsOpen()_ method can be used for health checking. The _IsOpen()_ shows the connection status based on the RabbitMQ heartbeat.
+It writes also the status of "antallKonsumenter" (number of subscribers) from the Fiks IO API, that also can be used for health checking. The status property "antallKonsumenter" is the registered number of subscribers in RabbitMQ.
 
 This is a very simple example of sending, receiving and replying to messages with this Fiks-IO-Client that logs information on the messages. It sends the `testfile.txt` file as payload, and prints the text inside the file when it receives the message.
 
 If you're using a Fiks-Protokoll account, please remember to add yourself as an approved sending account. This is only necessary for Fiks-Protokoll accounts.
-
-The program will also periodically print the status of the _IsOpen()_ health status of the Fiks-IO connection. The _IsOpen()_ method can be used for health checking. 
 
 ## Getting started
 

--- a/KS.Fiks.IO.Client.Tests/Catalog/CatalogHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Catalog/CatalogHandlerFixture.cs
@@ -18,6 +18,7 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
     {
         private HttpStatusCode _statusCode = HttpStatusCode.OK;
         private KatalogKonto _katalogKonto;
+        private KontoSvarStatus _status;
         private KontoOffentligNokkel _kontoOffentligNokkel;
         private string _scheme = "http";
         private string _host = "api.fiks.dev.ks";
@@ -26,6 +27,7 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
         private string _accessToken = "token";
         private string _integrasjonPassword = "default";
         private Guid _integrasjonId;
+        public Guid DefaultKontoId = Guid.NewGuid();
 
         public CatalogHandlerFixture()
         {
@@ -62,6 +64,12 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
         public CatalogHandlerFixture WithAccountResponse(KatalogKonto response)
         {
             _katalogKonto = response;
+            return this;
+        }
+
+        public CatalogHandlerFixture WithStatusResponse(KontoSvarStatus response)
+        {
+            _status = response;
             return this;
         }
 
@@ -174,6 +182,11 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
             if (_katalogKonto != null)
             {
                 return new StringContent(JsonConvert.SerializeObject(_katalogKonto));
+            }
+
+            if (_status != null)
+            {
+                return new StringContent(JsonConvert.SerializeObject(_status));
             }
 
             if (_kontoOffentligNokkel != null)

--- a/KS.Fiks.IO.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -38,7 +38,8 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
                 {
                     Melding = "No melding",
                     GyldigAvsender = true,
-                    GyldigMottaker = false
+                    GyldigMottaker = false,
+                    AntallKonsumenter = 3
                 }
             };
             var sut = _fixture.WithAccountResponse(expectedAccount).CreateSut();
@@ -51,6 +52,27 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
             result.KontoNavn.Should().Be(expectedAccount.KontoNavn);
             result.IsGyldigAvsender.Should().Be(expectedAccount.Status.GyldigAvsender);
             result.IsGyldigMottaker.Should().Be(expectedAccount.Status.GyldigMottaker);
+            result.AntallKonsumenter.Should().Be(expectedAccount.Status.AntallKonsumenter);
+        }
+
+        [Fact]
+        public async Task GetsExpectedStatus()
+        {
+            var expectedStatus = new KontoSvarStatus()
+            {
+                Melding = "No melding",
+                GyldigAvsender = true,
+                GyldigMottaker = false,
+                AntallKonsumenter = 3
+            };
+            var sut = _fixture.WithStatusResponse(expectedStatus).CreateSut();
+
+            var result = await sut.GetStatus(_fixture.DefaultKontoId).ConfigureAwait(false);
+
+            result.IsGyldigAvsender.Should().Be(expectedStatus.GyldigAvsender);
+            result.IsGyldigMottaker.Should().Be(expectedStatus.GyldigMottaker);
+            result.AntallKonsumenter.Should().Be(expectedStatus.AntallKonsumenter);
+            result.Melding.Should().Be(expectedStatus.Melding);
         }
 
         [Fact]
@@ -206,7 +228,8 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
                 {
                     Melding = "Melding",
                     GyldigAvsender = true,
-                    GyldigMottaker = false
+                    GyldigMottaker = false,
+                    AntallKonsumenter = 9
                 }
             };
             var sut = _fixture.WithAccountResponse(expectedAccount).CreateSut();
@@ -221,6 +244,7 @@ namespace KS.Fiks.IO.Client.Tests.Catalog
             result.Kommunenummer.Should().Be(expectedAccount.Kommunenummer);
             result.IsGyldigAvsender.Should().Be(expectedAccount.Status.GyldigAvsender);
             result.IsGyldigMottaker.Should().Be(expectedAccount.Status.GyldigMottaker);
+            result.AntallKonsumenter.Should().Be(expectedAccount.Status.AntallKonsumenter);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Client/Catalog/CatalogHandler.cs
@@ -21,6 +21,8 @@ namespace KS.Fiks.IO.Client.Catalog
 
         private const string AccountsEndpoint = "kontoer";
 
+        private const string StatusEndpoint = "status";
+
         private const string IdentifyerQueryName = "identifikator";
 
         private const string MessageProtocolQueryName = "meldingProtokoll";
@@ -59,6 +61,13 @@ namespace KS.Fiks.IO.Client.Catalog
             return Konto.FromKatalogModel(responseAsAccount);
         }
 
+        public async Task<Status> GetStatus(Guid kontoId)
+        {
+            var requestUri = CreateGetKontoStatusUri(kontoId);
+            var responseAsAccount = await GetAsModel<KontoSvarStatus>(requestUri).ConfigureAwait(false);
+            return Status.FromKatalogModel(responseAsAccount);
+        }
+
         public async Task<X509Certificate> GetPublicKey(Guid receiverAccountId)
         {
             var requestUri = CreatePublicKeyUri(receiverAccountId);
@@ -91,8 +100,19 @@ namespace KS.Fiks.IO.Client.Catalog
                     query)
                 .Uri;
         }
-        
+
         private Uri CreateGetKontoUri(Guid kontoId)
+        {
+            var servicePath = $"{_katalogConfiguration.Path}/{AccountsEndpoint}/{kontoId.ToString()}";
+            return new UriBuilder(
+                    _katalogConfiguration.Scheme,
+                    _katalogConfiguration.Host,
+                    _katalogConfiguration.Port,
+                    servicePath)
+                .Uri;
+        }
+
+        private Uri CreateGetKontoStatusUri(Guid kontoId)
         {
             var servicePath = $"{_katalogConfiguration.Path}/{AccountsEndpoint}/{kontoId.ToString()}";
             return new UriBuilder(

--- a/KS.Fiks.IO.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Client/Catalog/CatalogHandler.cs
@@ -114,7 +114,7 @@ namespace KS.Fiks.IO.Client.Catalog
 
         private Uri CreateGetKontoStatusUri(Guid kontoId)
         {
-            var servicePath = $"{_katalogConfiguration.Path}/{AccountsEndpoint}/{kontoId.ToString()}";
+            var servicePath = $"{_katalogConfiguration.Path}/{AccountsEndpoint}/{kontoId.ToString()}/{StatusEndpoint}";
             return new UriBuilder(
                     _katalogConfiguration.Scheme,
                     _katalogConfiguration.Host,

--- a/KS.Fiks.IO.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Client/Catalog/CatalogHandler.cs
@@ -65,7 +65,7 @@ namespace KS.Fiks.IO.Client.Catalog
         {
             var requestUri = CreateGetKontoStatusUri(kontoId);
             var responseAsAccount = await GetAsModel<KontoSvarStatus>(requestUri).ConfigureAwait(false);
-            return Status.FromKatalogModel(responseAsAccount);
+            return Status.FromKontoSvarStatusModel(responseAsAccount);
         }
 
         public async Task<X509Certificate> GetPublicKey(Guid receiverAccountId)

--- a/KS.Fiks.IO.Client/Catalog/ICatalogHandler.cs
+++ b/KS.Fiks.IO.Client/Catalog/ICatalogHandler.cs
@@ -12,5 +12,7 @@ namespace KS.Fiks.IO.Client.Catalog
         Task<Konto> GetKonto(Guid kontoId);
 
         Task<X509Certificate> GetPublicKey(Guid receiverAccountId);
+
+        Task<Status> GetStatus(Guid receiverAccountId);
     }
 }

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -162,6 +162,11 @@ namespace KS.Fiks.IO.Client
             return await _catalogHandler.GetKonto(kontoId).ConfigureAwait(false);
         }
 
+        public async Task<Status> GetKontoStatus(Guid kontoId)
+        {
+            return await _catalogHandler.GetStatus(kontoId).ConfigureAwait(false);
+        }
+
         public async Task<SendtMelding> Send(MeldingRequest request)
         {
             return await Send(request, new List<IPayload>()).ConfigureAwait(false);

--- a/KS.Fiks.IO.Client/IFiksIOClient.cs
+++ b/KS.Fiks.IO.Client/IFiksIOClient.cs
@@ -15,6 +15,8 @@ namespace KS.Fiks.IO.Client
 
         Task<Konto> GetKonto(Guid kontoId);
 
+        Task<Status> GetKontoStatus(Guid kontoId);
+
         Task<SendtMelding> Send(MeldingRequest request);
 
         Task<SendtMelding> Send(MeldingRequest request, IList<IPayload> payload);

--- a/KS.Fiks.IO.Client/Models/Konto.cs
+++ b/KS.Fiks.IO.Client/Models/Konto.cs
@@ -20,6 +20,8 @@ namespace KS.Fiks.IO.Client.Models
 
         public bool IsGyldigMottaker { get; set; }
 
+        public long AntallKonsumenter { get; set; }
+
         internal static Konto FromKatalogModel(KatalogKonto katalogKonto)
         {
             return new Konto
@@ -31,7 +33,8 @@ namespace KS.Fiks.IO.Client.Models
                 KontoId = katalogKonto.KontoId,
                 KontoNavn = katalogKonto.KontoNavn,
                 IsGyldigAvsender = katalogKonto.Status.GyldigAvsender,
-                IsGyldigMottaker = katalogKonto.Status.GyldigMottaker
+                IsGyldigMottaker = katalogKonto.Status.GyldigMottaker,
+                AntallKonsumenter = katalogKonto.Status.AntallKonsumenter
             };
         }
     }

--- a/KS.Fiks.IO.Client/Models/KontoSvarStatus.cs
+++ b/KS.Fiks.IO.Client/Models/KontoSvarStatus.cs
@@ -10,6 +10,9 @@ namespace KS.Fiks.IO.Client.Models
         [JsonProperty("gyldigMottaker")]
         public bool GyldigMottaker { get; set; }
 
+        [JsonProperty("antallKonsumenter")]
+        public long AntallKonsumenter { get; set; }
+
         [JsonProperty("melding")]
         public string Melding { get; set; }
     }

--- a/KS.Fiks.IO.Client/Models/Status.cs
+++ b/KS.Fiks.IO.Client/Models/Status.cs
@@ -12,7 +12,7 @@ namespace KS.Fiks.IO.Client.Models
 
         public string Melding { get; set; }
 
-        internal static Status FromKatalogModel(KontoSvarStatus kontoSvarStatus)
+        internal static Status FromKontoSvarStatusModel(KontoSvarStatus kontoSvarStatus)
         {
             return new Status
             {

--- a/KS.Fiks.IO.Client/Models/Status.cs
+++ b/KS.Fiks.IO.Client/Models/Status.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace KS.Fiks.IO.Client.Models
+{
+    public class Status
+    {
+        public bool IsGyldigAvsender { get; set; }
+
+        public bool IsGyldigMottaker { get; set; }
+
+        public long AntallKonsumenter { get; set; }
+
+        public string Melding { get; set; }
+
+        internal static Status FromKatalogModel(KontoSvarStatus kontoSvarStatus)
+        {
+            return new Status
+            {
+                IsGyldigAvsender = kontoSvarStatus.GyldigAvsender,
+                IsGyldigMottaker = kontoSvarStatus.GyldigMottaker,
+                AntallKonsumenter = kontoSvarStatus.AntallKonsumenter,
+                Melding = kontoSvarStatus.Melding
+            };
+        }
+    }
+}


### PR DESCRIPTION
Denne henger sammen med at Fiks-IO katalogservice har fått antall konsumenter ut som en property på både /lookup og /status endepunktene.
Tjenesten er releaset så denne kan nå releases også. Integrasjonstester må også evt. oppdateres.