### PR TITLE
Endringer for å kunne oppdatere til FiksIO sender 2.0

### DIFF
--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="KS.Fiks.ASiC-E" Version="2.0.1" />
-        <PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.12" />
+        <PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.0" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1">

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -14,6 +14,7 @@ using KS.Fiks.IO.Client.Send;
 using Ks.Fiks.Maskinporten.Client;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client.Events;
+using IntegrasjonConfiguration = KS.Fiks.IO.Send.Client.Configuration.IntegrasjonConfiguration;
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 
@@ -79,7 +80,7 @@ namespace KS.Fiks.IO.Client
                                _catalogHandler,
                                _maskinportenClient,
                                configuration.FiksIOSenderConfiguration,
-                               configuration.IntegrasjonConfiguration,
+                               new IntegrasjonConfiguration(configuration.IntegrasjonConfiguration.IntegrasjonId, configuration.IntegrasjonConfiguration.IntegrasjonPassord, configuration.IntegrasjonConfiguration.Scope),
                                httpClient,
                                asicEncrypter,
                                publicKeyProvider ?? new CatalogPublicKeyProvider(_catalogHandler));

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -13,7 +13,7 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>FIKS</PackageTags>
 		<VersionPrefix>4.0.7</VersionPrefix>
-		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<AssemblyVersion>4.0.0.0</AssemblyVersion>
@@ -44,7 +44,7 @@
 	<ItemGroup>
 		<PackageReference Include="KS.Fiks.ASiC-E" Version="2.0.1" />
 		<PackageReference Include="KS.Fiks.Crypto" Version="2.0.3" />
-		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="1.0.12" />
+		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.0" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
 		<PackageReference Include="RabbitMQ.Client" Version="6.8.1" />

--- a/KS.Fiks.IO.Client/Send/SendHandler.cs
+++ b/KS.Fiks.IO.Client/Send/SendHandler.cs
@@ -4,11 +4,11 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Asic;
 using KS.Fiks.IO.Client.Catalog;
-using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Send.Client;
 using KS.Fiks.IO.Send.Client.Configuration;
 using Ks.Fiks.Maskinporten.Client;
+using IntegrasjonConfiguration = KS.Fiks.IO.Send.Client.Configuration.IntegrasjonConfiguration;
 
 namespace KS.Fiks.IO.Client.Send
 {


### PR DESCRIPTION
Ser vi måtte endre fra netstandard2.0 til netstandard2.1. 
Er det da en major release kanskje? 🤔 