### PR TITLE
Update NuGet packages and bump major VersionPrefix

### DIFF
--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -12,12 +12,12 @@
 		<RepositoryUrl>https://github.com/ks-no/fiks-io-client-dotnet.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>FIKS</PackageTags>
-		<VersionPrefix>4.0.8</VersionPrefix>
+		<VersionPrefix>5.0.0</VersionPrefix>
 		<TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<AssemblyVersion>4.0.0.0</AssemblyVersion>
-		<FileVersion>4.0.0.0</FileVersion>
+		<AssemblyVersion>5.0.0.0</AssemblyVersion>
+		<FileVersion>5.0.0.0</FileVersion>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>../fiks-io-strongly-named-key.snk</AssemblyOriginatorKeyFile>
@@ -50,5 +50,6 @@
 		<PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
* La til System.Text.Json 8.0.5 pga sårbarhet i 8.0.0 som indirekte ble brukt av andre dependencies. 
* Bumpet også klienten en major til 5.0.0 ettersom man må bytte noen using statements etter noen modeller ble flyttet:
   * using KS.Fiks.IO._Client_.Models;    --> using KS.Fiks.IO._Crypto_.Models;