### PR TITLE
Erstattet FluentAssertions med Shouldly

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Exceptions;
 using KS.Fiks.IO.Client.Models;
 using Moq;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Amqp
@@ -65,7 +65,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             sut.AddMessageReceivedHandler(handler, null);
 
             _fixture.AmqpReceiveConsumerMock.Raise(_ => _.Received += null, this, null);
-            counter.Should().Be(1);
+            counter.ShouldBe(1);
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             sut.AddMessageReceivedHandler(null, handler);
 
             _fixture.AmqpReceiveConsumerMock.Raise(_ => _.ConsumerCancelled += null, this, null);
-            counter.Should().Be(1);
+            counter.ShouldBe(1);
         }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerTests.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Exceptions;
 using KS.Fiks.IO.Client.FileIO;
 using KS.Fiks.IO.Client.Models;
@@ -12,6 +11,7 @@ using KS.Fiks.IO.Client.Utility;
 using KS.Fiks.IO.Crypto.Asic;
 using Moq;
 using RabbitMQ.Client;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Amqp
@@ -44,7 +44,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 Array.Empty<byte>());
 
-            hasBeenCalled.Should().BeTrue();
+            hasBeenCalled.ShouldBeTrue();
         }
 
         [Fact]
@@ -90,14 +90,14 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 propertiesMock.Object,
                 Array.Empty<byte>());
 
-            actualMelding.MeldingId.Should().Be(expectedMessageMetadata.MeldingId);
-            actualMelding.MeldingType.Should().Be(expectedMessageMetadata.MeldingType);
-            actualMelding.MottakerKontoId.Should().Be(expectedMessageMetadata.MottakerKontoId);
-            actualMelding.AvsenderKontoId.Should().Be(expectedMessageMetadata.AvsenderKontoId);
-            actualMelding.SvarPaMelding.Should().Be(expectedMessageMetadata.SvarPaMelding);
-            actualMelding.Ttl.Should().Be(expectedMessageMetadata.Ttl);
-            actualMelding.Headere["test"].ToString().Should().Be("Test");
-            actualMelding.Resendt.Should().BeFalse();
+            actualMelding.MeldingId.ShouldBe(expectedMessageMetadata.MeldingId);
+            actualMelding.MeldingType.ShouldBe(expectedMessageMetadata.MeldingType);
+            actualMelding.MottakerKontoId.ShouldBe(expectedMessageMetadata.MottakerKontoId);
+            actualMelding.AvsenderKontoId.ShouldBe(expectedMessageMetadata.AvsenderKontoId);
+            actualMelding.SvarPaMelding.ShouldBe(expectedMessageMetadata.SvarPaMelding);
+            actualMelding.Ttl.ShouldBe(expectedMessageMetadata.Ttl);
+            actualMelding.Headere["test"].ToString().ShouldBe("Test");
+            actualMelding.Resendt.ShouldBeFalse();
         }
 
         [Fact]
@@ -143,14 +143,14 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 propertiesMock.Object,
                 Array.Empty<byte>());
 
-            actualMelding.MeldingId.Should().Be(expectedMessageMetadata.MeldingId);
-            actualMelding.MeldingType.Should().Be(expectedMessageMetadata.MeldingType);
-            actualMelding.MottakerKontoId.Should().Be(expectedMessageMetadata.MottakerKontoId);
-            actualMelding.AvsenderKontoId.Should().Be(expectedMessageMetadata.AvsenderKontoId);
-            actualMelding.SvarPaMelding.Should().Be(expectedMessageMetadata.SvarPaMelding);
-            actualMelding.Ttl.Should().Be(expectedMessageMetadata.Ttl);
-            actualMelding.Headere["test"].ToString().Should().Be("Test");
-            actualMelding.Resendt.Should().BeTrue();
+            actualMelding.MeldingId.ShouldBe(expectedMessageMetadata.MeldingId);
+            actualMelding.MeldingType.ShouldBe(expectedMessageMetadata.MeldingType);
+            actualMelding.MottakerKontoId.ShouldBe(expectedMessageMetadata.MottakerKontoId);
+            actualMelding.AvsenderKontoId.ShouldBe(expectedMessageMetadata.AvsenderKontoId);
+            actualMelding.SvarPaMelding.ShouldBe(expectedMessageMetadata.SvarPaMelding);
+            actualMelding.Ttl.ShouldBe(expectedMessageMetadata.Ttl);
+            actualMelding.Headere["test"].ToString().ShouldBe("Test");
+            actualMelding.Resendt.ShouldBeTrue();
         }
 
         [Fact]
@@ -356,8 +356,8 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             var actualData = new byte[2];
             await actualDataStream.ReadAsync(actualData, 0, 2).ConfigureAwait(false);
 
-            actualData[0].Should().Be(data[0]);
-            actualData[1].Should().Be(data[1]);
+            actualData[0].ShouldBe(data[0]);
+            actualData[1].ShouldBe(data[1]);
         }
 
         [Fact]
@@ -388,8 +388,8 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
             var actualData = new byte[2];
             await actualDataStream.ReadAsync(actualData, 0, 2).ConfigureAwait(false);
-            actualData[0].Should().Be(data[0]);
-            actualData[1].Should().Be(data[1]);
+            actualData[0].ShouldBe(data[0]);
+            actualData[1].ShouldBe(data[1]);
         }
 
         [Fact]
@@ -489,7 +489,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            correctExceptionThrown.Should().BeTrue();
+            correctExceptionThrown.ShouldBeTrue();
         }
 
         [Fact]
@@ -522,7 +522,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            correctExceptionThrown.Should().BeTrue();
+            correctExceptionThrown.ShouldBeTrue();
         }
 
         [Fact]
@@ -555,7 +555,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            correctExceptionThrown.Should().BeTrue();
+            correctExceptionThrown.ShouldBeTrue();
         }
 
         [Fact]
@@ -588,7 +588,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            correctExceptionThrown.Should().BeTrue();
+            correctExceptionThrown.ShouldBeTrue();
         }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIOConfigurationBuilderTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIOConfigurationBuilderTests.cs
@@ -1,10 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Send.Client.Configuration;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Configuration
@@ -23,8 +22,8 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .WithFiksKontoConfiguration(Guid.NewGuid(), "liksom-en-private-key")
                 .BuildTestConfiguration();
 
-            configuration.ApiConfiguration.Host.Should().Be(ApiConfiguration.TestHost);
-            configuration.AmqpConfiguration.Host.Should().Be(AmqpConfiguration.TestHost);
+            configuration.ApiConfiguration.Host.ShouldBe(ApiConfiguration.TestHost);
+            configuration.AmqpConfiguration.Host.ShouldBe(AmqpConfiguration.TestHost);
         }
 
         [Fact]
@@ -39,8 +38,8 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .WithFiksKontoConfiguration(Guid.NewGuid(), "liksom-en-private-key")
                 .BuildProdConfiguration();
 
-            configuration.ApiConfiguration.Host.Should().Be(ApiConfiguration.ProdHost);
-            configuration.AmqpConfiguration.Host.Should().Be(AmqpConfiguration.ProdHost);
+            configuration.ApiConfiguration.Host.ShouldBe(ApiConfiguration.ProdHost);
+            configuration.AmqpConfiguration.Host.ShouldBe(AmqpConfiguration.ProdHost);
         }
 
         [Fact]
@@ -56,7 +55,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .WithFiksKontoConfiguration(Guid.NewGuid(), dummyPrivateKey)
                 .BuildTestConfiguration();
 
-            config.KontoConfiguration.PrivatNokler.Single().Should().Be(dummyPrivateKey);
+            config.KontoConfiguration.PrivatNokler.Single().ShouldBe(dummyPrivateKey);
         }
 
         [Fact]
@@ -72,7 +71,7 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 .WithFiksKontoConfiguration(Guid.NewGuid(), dummyPrivateKeys)
                 .BuildTestConfiguration();
 
-            config.KontoConfiguration.PrivatNokler.Should().BeEquivalentTo(dummyPrivateKeys);
+            config.KontoConfiguration.PrivatNokler.ShouldBeEquivalentTo(dummyPrivateKeys);
         }
 
         [Fact]

--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIODefaultConfigurationTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Configuration;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Configuration
@@ -29,10 +29,10 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 maskinportenSertifikat: maskinportenSertifikat,
                 asiceSertifikat: asiceSertifikat);
 
-            config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
-            config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
-            config.AmqpConfiguration.Host.Should().Be("io.fiks.ks.no");
-            config.ApiConfiguration.Host.Should().Be("api.fiks.ks.no");
+            config.IntegrasjonConfiguration.IntegrasjonId.ShouldBe(integrationId);
+            config.IntegrasjonConfiguration.IntegrasjonPassord.ShouldBe(integrationPassord);
+            config.AmqpConfiguration.Host.ShouldBe("io.fiks.ks.no");
+            config.ApiConfiguration.Host.ShouldBe("api.fiks.ks.no");
         }
 
         [Fact]
@@ -56,10 +56,10 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 maskinportenSertifikat: maskinportenSertifikat,
                 asiceSertifikat: asiceSertifikat);
 
-            config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
-            config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
-            config.AmqpConfiguration.Host.Should().Be("io.fiks.ks.no");
-            config.ApiConfiguration.Host.Should().Be("api.fiks.ks.no");
+            config.IntegrasjonConfiguration.IntegrasjonId.ShouldBe(integrationId);
+            config.IntegrasjonConfiguration.IntegrasjonPassord.ShouldBe(integrationPassord);
+            config.AmqpConfiguration.Host.ShouldBe("io.fiks.ks.no");
+            config.ApiConfiguration.Host.ShouldBe("api.fiks.ks.no");
         }
 
         [Fact]
@@ -84,10 +84,10 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 asiceSertifikat: asiceSertifikat
             );
 
-            config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
-            config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
-            config.AmqpConfiguration.Host.Should().Be("io.fiks.test.ks.no");
-            config.ApiConfiguration.Host.Should().Be("api.fiks.test.ks.no");
+            config.IntegrasjonConfiguration.IntegrasjonId.ShouldBe(integrationId);
+            config.IntegrasjonConfiguration.IntegrasjonPassord.ShouldBe(integrationPassord);
+            config.AmqpConfiguration.Host.ShouldBe("io.fiks.test.ks.no");
+            config.ApiConfiguration.Host.ShouldBe("api.fiks.test.ks.no");
         }
 
         [Fact]
@@ -112,10 +112,10 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 asiceSertifikat: asiceSertifikat
             );
 
-            config.IntegrasjonConfiguration.IntegrasjonId.Should().Be(integrationId);
-            config.IntegrasjonConfiguration.IntegrasjonPassord.Should().Be(integrationPassord);
-            config.AmqpConfiguration.Host.Should().Be("io.fiks.test.ks.no");
-            config.ApiConfiguration.Host.Should().Be("api.fiks.test.ks.no");
+            config.IntegrasjonConfiguration.IntegrasjonId.ShouldBe(integrationId);
+            config.IntegrasjonConfiguration.IntegrasjonPassord.ShouldBe(integrationPassord);
+            config.AmqpConfiguration.Host.ShouldBe("io.fiks.test.ks.no");
+            config.ApiConfiguration.Host.ShouldBe("api.fiks.test.ks.no");
         }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Dokumentlager/DokumentlagerHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Dokumentlager/DokumentlagerHandlerTests.cs
@@ -2,10 +2,10 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Exceptions;
 using Moq;
 using Moq.Protected;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Dokumentlager
@@ -38,7 +38,7 @@ namespace KS.Fiks.IO.Client.Tests.Dokumentlager
 
             var result = await sut.Download(messageId).ConfigureAwait(false);
 
-            _fixture.RequestUri.ToString().Should().Be(expectedUri);
+            _fixture.RequestUri.ToString().ShouldBe(expectedUri);
 
             _fixture.HttpMessageHandleMock.Protected().Verify(
                 "SendAsync",

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Crypto.Models;
 using KS.Fiks.IO.Send.Client.Models;
 using Moq;
 using RabbitMQ.Client.Events;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests
@@ -28,7 +28,7 @@ namespace KS.Fiks.IO.Client.Tests
             var expectedAccountId = Guid.NewGuid();
             var sut = _fixture.WithAccountId(expectedAccountId).CreateSut();
             var actualAccountId = sut.KontoId;
-            actualAccountId.Should().Be(expectedAccountId);
+            actualAccountId.ShouldBe(expectedAccountId);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace KS.Fiks.IO.Client.Tests
                 3);
             var sut = _fixture.WithLookupAccount(expectedAccount).CreateSut();
             var actualAccount = await sut.Lookup(lookup).ConfigureAwait(false);
-            actualAccount.Should().Be(expectedAccount);
+            actualAccount.ShouldBe(expectedAccount);
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace KS.Fiks.IO.Client.Tests
 
             var result = await sut.Send(request, payload).ConfigureAwait(false);
 
-            result.Should().Be(expectedMessage);
+            result.ShouldBe(expectedMessage);
         }
 
         [Fact]

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
         <PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -14,7 +14,6 @@
         <CodeAnalysisRuleSet>..\fiks.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.2" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
@@ -27,6 +26,7 @@
         <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
         <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
         <PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>

--- a/KS.Fiks.IO.Client.Tests/Models/MeldingRequestTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Models/MeldingRequestTests.cs
@@ -1,6 +1,6 @@
 using System;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Models;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Models
@@ -14,7 +14,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 Guid.NewGuid(),
                 Guid.NewGuid(),
                 "meldingType").ToApiModel();
-            result.Headere.Should().BeEmpty();
+            result.Headere.ShouldBeEmpty();
         }
 
         [Fact]
@@ -26,9 +26,9 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 Guid.NewGuid(),
                 "meldingType",
                 klientMeldingId: klientMeldingId).ToApiModel();
-            result.Headere.Should().NotBeEmpty();
-            result.Headere.ContainsKey(MeldingBase.headerKlientMeldingId).Should().BeTrue();
-            result.Headere.ContainsValue(klientMeldingId.ToString()).Should().BeTrue();
+            result.Headere.ShouldNotBeEmpty();
+            result.Headere.ContainsKey(MeldingBase.headerKlientMeldingId).ShouldBeTrue();
+            result.Headere.ContainsValue(klientMeldingId.ToString()).ShouldBeTrue();
         }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Models/MottattMeldingTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Models/MottattMeldingTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Models;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Models
@@ -17,7 +17,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere), null, null, null);
 
-            mottattMelding.KlientMeldingId.Should().Be(klientMeldingId);
+            mottattMelding.KlientMeldingId.ShouldBe(klientMeldingId);
         }
 
         [Fact]
@@ -29,8 +29,8 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere), null, null, null);
 
-            mottattMelding.KlientMeldingId.Should().Be(Guid.Empty);
-            mottattMelding.Headere.Values.Should().Contain(klientMeldingId);
+            mottattMelding.KlientMeldingId.ShouldBe(Guid.Empty);
+            mottattMelding.Headere.Values.ShouldContain(klientMeldingId);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, null), null, null, null);
 
-            mottattMelding.KlientMeldingId.Should().BeNull();
+            mottattMelding.KlientMeldingId.ShouldBeNull();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere), null, null, null);
 
-            mottattMelding.Resendt.Should().BeFalse();
+            mottattMelding.Resendt.ShouldBeFalse();
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere, resendt), null, null, null);
 
-            mottattMelding.Resendt.Should().BeTrue();
+            mottattMelding.Resendt.ShouldBeTrue();
         }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Models/SendtMeldingTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Models/SendtMeldingTests.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Send.Client.Models;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Models
@@ -25,7 +25,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                     Ttl = 1000L
                 });
 
-            result.KlientMeldingId.Should().BeNull();
+            result.KlientMeldingId.ShouldBeNull();
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                     Ttl = 1000L
                 });
 
-            result.KlientMeldingId.Should().BeNull();
+            result.KlientMeldingId.ShouldBeNull();
         }
 
         [Fact]
@@ -64,8 +64,8 @@ namespace KS.Fiks.IO.Client.Tests.Models
                     Ttl = 1000L
                 });
 
-            result.KlientMeldingId.Should().NotBeNull();
-            result.KlientMeldingId.Should().Be(klientMeldingId.ToString());
+            result.KlientMeldingId.ShouldNotBeNull();
+            result.KlientMeldingId.ShouldBe(klientMeldingId);
         }
     }
 }

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -44,12 +44,12 @@
 	<ItemGroup>
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.2" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
 		<PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
-		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+		<PackageReference Include="System.Text.Json" Version="9.0.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Dette er gjort: 

- Erstattet FluentAssertions med Shouldly
- Bumps [Serilog](https://github.com/serilog/serilog) from 4.1.0 to 4.2.0.
- Bumps [xunit](https://github.com/xunit/xunit) from 2.9.2 to 2.9.3.
- Bumps [System.Text.Json](https://github.com/dotnet/runtime) from 8.0.5 to 9.0.1.
- Bumps [Microsoft.Extensions.Hosting](https://github.com/dotnet/runtime) from 8.0.1 to 9.0.1.
- Bumps [Microsoft.Extensions.Logging](https://github.com/dotnet/runtime) from 8.0.1 to 9.0.1.
