### PR TITLE
New constructor FiksIOConfiguration without MaskinportenClientConfig

### DIFF
--- a/KS.Fiks.IO.Client.Tests/Configuration/FiksIOConfigurationTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Configuration/FiksIOConfigurationTests.cs
@@ -19,5 +19,14 @@ namespace KS.Fiks.IO.Client.Tests.Configuration
                 new MaskinportenClientConfiguration("aud", "tokenedm", "issuer",100, Mock.Of<X509Certificate2>()),
                 null);
         }
+
+        [Fact]
+        public void WorksWithNullMaskinportenClientConfigurationConstructor()
+        {
+            var result = new FiksIOConfiguration(
+                new KontoConfiguration(Guid.NewGuid(),"string"),
+                new IntegrasjonConfiguration(Guid.NewGuid(),"password"),
+                null);
+        }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
@@ -61,7 +61,22 @@ namespace KS.Fiks.IO.Client.Tests
 
         public FiksIOClient CreateSut()
         {
-            SetupConfiguration();
+            SetupConfiguration(true);
+            SetupMocks();
+            return FiksIOClient.CreateAsync(
+                _configuration,
+                null,
+                CatalogHandlerMock.Object,
+                MaskinportenClientMock.Object,
+                SendHandlerMock.Object,
+                DokumentlagerHandlerMock.Object,
+                AmqpHandlerMock.Object,
+                asicEncrypter: AsicEncrypterMock.Object).Result;
+        }
+
+        public FiksIOClient CreateSutWithoutMaskinportenConfig()
+        {
+            SetupConfiguration(false);
             SetupMocks();
             return FiksIOClient.CreateAsync(
                 _configuration,
@@ -138,15 +153,18 @@ namespace KS.Fiks.IO.Client.Tests
                 It.IsAny<EventHandler<ConsumerEventArgs>>()));
         }
 
-        private void SetupConfiguration()
+        private void SetupConfiguration(bool withMaskinportenConfig)
         {
             var apiConfiguration = new ApiConfiguration(_scheme, _host, _port);
             var accountConfiguration = new KontoConfiguration(_accountId, "dummyKey");
+            var maskinportenConfig = withMaskinportenConfig
+                ? new MaskinportenClientConfiguration("audience", "token", "issuer", 1, new X509Certificate2())
+                : null;
             _configuration = new FiksIOConfiguration(
                 accountConfiguration,
                 new IntegrasjonConfiguration(_integrasjonId, _integrasjonPassword),
-                new MaskinportenClientConfiguration("audience", "token", "issuer", 1, new X509Certificate2()),
-                new AsiceSigningConfiguration("",""),
+                maskinportenConfig,
+                new AsiceSigningConfiguration("", ""),
                 apiConfiguration: apiConfiguration,
                 katalogConfiguration: _katalogConfiguration);
         }

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
@@ -66,6 +66,9 @@ namespace KS.Fiks.IO.Client.Tests
             return FiksIOClient.CreateAsync(
                 _configuration,
                 null,
+                null,
+                null,
+                null,
                 CatalogHandlerMock.Object,
                 MaskinportenClientMock.Object,
                 SendHandlerMock.Object,
@@ -80,6 +83,9 @@ namespace KS.Fiks.IO.Client.Tests
             SetupMocks();
             return FiksIOClient.CreateAsync(
                 _configuration,
+                null,
+                null,
+                null,
                 null,
                 CatalogHandlerMock.Object,
                 MaskinportenClientMock.Object,

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
@@ -199,5 +199,25 @@ namespace KS.Fiks.IO.Client.Tests
 
             _fixture.AmqpHandlerMock.Verify(_ => _.AddMessageReceivedHandler(onReceived, onCanceled));
         }
+
+        [Fact]
+        public async Task SendCallsSendHandlerAsPayloadListWithOutMaskinportenConfig()
+        {
+            var sut = _fixture.CreateSutWithoutMaskinportenConfig();
+
+            var request = _fixture.DefaultRequest;
+
+            var stream = Mock.Of<Stream>();
+            var filename = "filename.file";
+
+            var result = await sut.Send(request, stream, filename).ConfigureAwait(false);
+
+            _fixture.SendHandlerMock.Verify(_ => _.Send(
+                request,
+                It.Is<IList<IPayload>>(actualPayload =>
+                    actualPayload.Count() == 1 &&
+                    actualPayload.FirstOrDefault().Payload == stream &&
+                    actualPayload.FirstOrDefault().Filename == filename)));
+        }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
@@ -4,7 +4,7 @@ using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
-    internal interface IAmqpHandler : IDisposable
+    public interface IAmqpHandler : IDisposable
     {
         void AddMessageReceivedHandler(
             EventHandler<MottattMeldingArgs> receivedEvent,

--- a/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
+++ b/KS.Fiks.IO.Client/Configuration/FiksIOConfiguration.cs
@@ -50,6 +50,31 @@ namespace KS.Fiks.IO.Client.Configuration
                 ApiConfiguration.Port);
         }
 
+        public FiksIOConfiguration(
+            KontoConfiguration kontoConfiguration,
+            IntegrasjonConfiguration integrasjonConfiguration,
+            AsiceSigningConfiguration asiceSigningConfiguration,
+            ApiConfiguration apiConfiguration = null,
+            AmqpConfiguration amqpConfiguration = null,
+            KatalogConfiguration katalogConfiguration = null,
+            FiksIOSenderConfiguration fiksIOSenderConfiguration = null,
+            DokumentlagerConfiguration dokumentlagerConfiguration = null
+        )
+        {
+            KontoConfiguration = kontoConfiguration;
+            IntegrasjonConfiguration = integrasjonConfiguration;
+            AsiceSigningConfiguration = asiceSigningConfiguration;
+            ApiConfiguration = apiConfiguration ?? new ApiConfiguration();
+            AmqpConfiguration = amqpConfiguration ?? new AmqpConfiguration(ApiConfiguration.Host);
+            KatalogConfiguration = katalogConfiguration ?? new KatalogConfiguration(ApiConfiguration);
+            DokumentlagerConfiguration = dokumentlagerConfiguration ?? new DokumentlagerConfiguration(ApiConfiguration);
+            FiksIOSenderConfiguration = fiksIOSenderConfiguration ?? new FiksIOSenderConfiguration(
+                null,
+                ApiConfiguration.Scheme,
+                ApiConfiguration.Host,
+                ApiConfiguration.Port);
+        }
+
         public FiksIOSenderConfiguration FiksIOSenderConfiguration { get; }
 
         public MaskinportenClientConfiguration MaskinportenConfiguration { get; }

--- a/KS.Fiks.IO.Client/Dokumentlager/IDokumentlagerHandler.cs
+++ b/KS.Fiks.IO.Client/Dokumentlager/IDokumentlagerHandler.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace KS.Fiks.IO.Client.Dokumentlager
 {
-    internal interface IDokumentlagerHandler
+    public interface IDokumentlagerHandler
     {
         Task<Stream> Download(Guid messageId);
     }

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -117,7 +117,7 @@ namespace KS.Fiks.IO.Client
             return client;
         }
 
-        internal static async Task<FiksIOClient> CreateAsync(
+        public static async Task<FiksIOClient> CreateAsync(
             FiksIOConfiguration configuration,
             LoggerFactory loggerFactory = null,
             ICatalogHandler catalogHandler = null,

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -110,25 +110,13 @@ namespace KS.Fiks.IO.Client
             ILoggerFactory loggerFactory = null,
             HttpClient httpClient = null,
             IPublicKeyProvider publicKeyProvider = null,
-            IAmqpWatcher amqpWatcher = null)
-        {
-            var client = new FiksIOClient(configuration, loggerFactory, httpClient, publicKeyProvider);
-            await client.InitializeAmqpHandlerAsync(configuration, amqpWatcher).ConfigureAwait(false);
-            return client;
-        }
-
-        public static async Task<FiksIOClient> CreateAsync(
-            FiksIOConfiguration configuration,
-            LoggerFactory loggerFactory = null,
+            IAmqpWatcher amqpWatcher = null,
             ICatalogHandler catalogHandler = null,
             IMaskinportenClient maskinportenClient = null,
             ISendHandler sendHandler = null,
             IDokumentlagerHandler dokumentlagerHandler = null,
             IAmqpHandler amqpHandler = null,
-            HttpClient httpClient = null,
-            IPublicKeyProvider publicKeyProvider = null,
-            IAsicEncrypter asicEncrypter = null,
-            IAmqpWatcher amqpWatcher = null)
+            IAsicEncrypter asicEncrypter = null)
         {
             var client = new FiksIOClient(
                 configuration,


### PR DESCRIPTION
Opprettet ny konstruktør i FiksIOConfiguration hvor MaskinportenClientConfig er fjernet. Skrevet et test på opprettelse av konstruktør og en klient test. 

Det er nå optional om man vil sende med MaskinportenClientConfiguration i konstruktøren.
