### PR TITLE
Fo 253

### DIFF
--- a/ExampleApplication/FiksIO/FiksIOSubscriber.cs
+++ b/ExampleApplication/FiksIO/FiksIOSubscriber.cs
@@ -86,7 +86,7 @@ namespace ExampleApplication.FiksIO
                 }
             }
 
-            mottatt.SvarSender.Ack(); 
+            await mottatt.SvarSender.AckAsync(); 
         }
 
         private static async Task<string> GetDecryptedPayloadTxt(MottattMeldingArgs mottattMeldingArgs)

--- a/ExampleApplication/FiksIO/FiksIOSubscriber.cs
+++ b/ExampleApplication/FiksIO/FiksIOSubscriber.cs
@@ -32,7 +32,7 @@ namespace ExampleApplication.FiksIO
             await Task.CompletedTask;
         }
 
-        private async void OnReceivedMelding(object sender, MottattMeldingArgs mottatt)
+        private async Task OnReceivedMelding(MottattMeldingArgs mottatt)
         {
             var receivedMeldingType = mottatt.Melding.MeldingType;
             var konto = await _fiksIoClient.GetKonto(mottatt.Melding.AvsenderKontoId);
@@ -117,7 +117,7 @@ namespace ExampleApplication.FiksIO
         {
             var accountId = _appSettings.FiksIOConfig.FiksIoAccountId;
             Log.Information($"FiksIOSubscriber - Starting FiksIOReceiveAndReplySubscriber subscribe on account {accountId}...");
-            _fiksIoClient.NewSubscription(OnReceivedMelding);
+            _fiksIoClient.NewSubscriptionAsync(OnReceivedMelding);
         }
     }
 }

--- a/ExampleApplication/Program.cs
+++ b/ExampleApplication/Program.cs
@@ -121,7 +121,7 @@ namespace ExampleApplication
                     await _messageSender.Send(FiksMatrikkelfoeringPing, _toAccountId);
                 } else if (key == ConsoleKey.L)
                 {
-                    WriteHeartBeatConnectionStatusToLog();
+                    await WriteHeartBeatConnectionStatusToLog();
                     await WriteStatusFromApiToLog();
                 }
     
@@ -144,9 +144,10 @@ namespace ExampleApplication
             return LoggerFactory.Create(logging => logging.AddSerilog(logger));
         }
         
-        private static void WriteHeartBeatConnectionStatusToLog()
+        private static async Task WriteHeartBeatConnectionStatusToLog()
         {
-            Log.Information($"FiksIOSubscriber status check - FiksIOClient connection IsOpen: {_fiksIoClient.IsOpen()}");
+            var isOpen = await _fiksIoClient.IsOpenAsync();
+            Log.Information($"FiksIOSubscriber status check - FiksIOClient connection IsOpen: {isOpen}");
         }
 
         private static async Task WriteStatusFromApiToLog()

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpConsumerFactoryTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpConsumerFactoryTests.cs
@@ -1,0 +1,42 @@
+using System;
+using KS.Fiks.IO.Client.Amqp;
+using KS.Fiks.IO.Client.Configuration;
+using KS.Fiks.IO.Client.Dokumentlager;
+using KS.Fiks.IO.Client.Send;
+using Moq;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace KS.Fiks.IO.Client.Tests.Amqp
+{
+    public class AmqpConsumerFactoryTests
+    {
+        private readonly Mock<IChannel> _channelMock;
+        private readonly AmqpConsumerFactory _factory;
+
+        public AmqpConsumerFactoryTests()
+        {
+            var sendHandlerMock = new Mock<ISendHandler>();
+            var dokumentlagerHandlerMock = new Mock<IDokumentlagerHandler>();
+            var amqpWatcherMock = new Mock<IAmqpWatcher>();
+            _channelMock = new Mock<IChannel>();
+
+            var kontoConfiguration = new KontoConfiguration(Guid.NewGuid(), "private-key");
+
+            _factory = new AmqpConsumerFactory(
+                sendHandlerMock.Object,
+                dokumentlagerHandlerMock.Object,
+                amqpWatcherMock.Object,
+                kontoConfiguration);
+        }
+
+        [Fact]
+        public void CreateReceiveConsumer_ReturnsAmqpReceiveConsumer()
+        {
+            var consumer = _factory.CreateReceiveConsumer(_channelMock.Object);
+
+            Assert.NotNull(consumer);
+            Assert.IsType<AmqpReceiveConsumer>(consumer);
+        }
+    }
+}

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
@@ -10,7 +10,6 @@ using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Client.Send;
 using KS.Fiks.IO.Send.Client.Configuration;
 using Ks.Fiks.Maskinporten.Client;
-using Microsoft.Extensions.Logging;
 using Moq;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
@@ -1,14 +1,18 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Amqp;
 using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Client.Dokumentlager;
+using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Client.Send;
 using KS.Fiks.IO.Send.Client.Configuration;
 using Ks.Fiks.Maskinporten.Client;
 using Moq;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 
 namespace KS.Fiks.IO.Client.Tests.Amqp
@@ -22,7 +26,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         private Guid _integrationId = Guid.NewGuid();
         private string _integrationPassword = "defaultPassword";
 
-        public AmqpHandlerFixture WhereConnectionfactoryThrowsException()
+        public AmqpHandlerFixture WhereConnectionFactoryThrowsException()
         {
             _connectionFactoryShouldThrow = true;
             return this;
@@ -52,8 +56,6 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             return this;
         }
 
-        public Mock<IModel> ModelMock { get; } = new Mock<IModel>();
-
         public Mock<IConnectionFactory> ConnectionFactoryMock { get; } = new Mock<IConnectionFactory>();
 
         public Mock<IConnection> ConnectionMock { get; } = new Mock<IConnection>();
@@ -68,29 +70,11 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
         internal Mock<ISendHandler> SendHandlerMock { get; } = new Mock<ISendHandler>();
 
-        internal IAmqpHandler CreateSut()
+        internal async Task<IAmqpHandler> CreateSutAsync()
         {
             SetupMocks();
             var amqpConfiguration = CreateConfiguration();
-            var amqpHandler = AmqpHandler.CreateAsync(
-                    MaskinportenClientMock.Object,
-                     SendHandlerMock.Object,
-                     DokumentlagerHandlerMock.Object,
-                     amqpConfiguration,
-                     CreateIntegrationConfiguration(),
-                     new KontoConfiguration(_accountId, "dummy"),
-                     null,
-                     ConnectionFactoryMock.Object,
-                     AmqpConsumerFactoryMock.Object).Result;
-
-            return amqpHandler;
-        }
-
-        internal Task<IAmqpHandler> CreateSutAsync()
-        {
-            SetupMocks();
-            var amqpConfiguration = CreateConfiguration();
-            var amqpHandler = AmqpHandler.CreateAsync(
+            var amqpHandler = await AmqpHandler.CreateAsync(
                 MaskinportenClientMock.Object,
                 SendHandlerMock.Object,
                 DokumentlagerHandlerMock.Object,
@@ -99,7 +83,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 new KontoConfiguration(_accountId, "dummy"),
                 null,
                 ConnectionFactoryMock.Object,
-                AmqpConsumerFactoryMock.Object);
+                AmqpConsumerFactoryMock.Object).ConfigureAwait(false);
 
             return amqpHandler;
         }
@@ -111,34 +95,59 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
         private void SetupMocks()
         {
+            ConnectionMock
+                .Setup(connection => connection.CreateChannelAsync(It.IsAny<CreateChannelOptions?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<IChannel>().Object);
             if (_connectionFactoryShouldThrow)
             {
-                ConnectionFactoryMock.Setup(_ => _.CreateConnection(It.IsAny<IList<AmqpTcpEndpoint>>(), It.IsAny<string>()))
-                                     .Throws<ProtocolViolationException>();
+                ConnectionFactoryMock
+                    .Setup(factory => factory.CreateConnectionAsync(
+                        It.IsAny<IList<AmqpTcpEndpoint>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<CancellationToken>()))
+                    .Throws<ProtocolViolationException>();
             }
             else
             {
-                ConnectionFactoryMock.Setup(_ => _.CreateConnection(It.IsAny<IList<AmqpTcpEndpoint>>(), It.IsAny<string>()))
-                                     .Returns(ConnectionMock.Object);
+                ConnectionFactoryMock
+                    .Setup(factory => factory.CreateConnectionAsync(
+                        It.IsAny<IList<AmqpTcpEndpoint>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(ConnectionMock.Object);
             }
 
-            ConnectionFactoryMock.SetupSet(_ => _.Password = It.IsAny<string>());
-            ConnectionFactoryMock.SetupSet(_ => _.UserName = It.IsAny<string>());
+            ConnectionFactoryMock.SetupSet(connection => connection.Password = It.IsAny<string>());
+            ConnectionFactoryMock.SetupSet(connection => connection.UserName = It.IsAny<string>());
 
             if (_connectionShouldThrow)
             {
-                ConnectionMock.Setup(_ => _.CreateModel()).Throws<ProtocolViolationException>();
+                ConnectionMock
+                    .Setup(connection => connection.CreateChannelAsync(It.IsAny<CreateChannelOptions?>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new ProtocolViolationException("Simulated channel creation failure"));
             }
             else
             {
-                ConnectionMock.Setup(_ => _.CreateModel()).Returns(ModelMock.Object);
+                ConnectionMock
+                    .Setup(connection => connection.CreateChannelAsync(It.IsAny<CreateChannelOptions?>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new Mock<IChannel>().Object);
             }
 
-            AmqpConsumerFactoryMock.Setup(_ => _.CreateReceiveConsumer(It.IsAny<IModel>()))
-                                   .Returns(AmqpReceiveConsumerMock.Object);
+            AmqpConsumerFactoryMock
+                .Setup(consumerFactory => consumerFactory.CreateReceiveConsumer(It.IsAny<IChannel>()))
+                .Returns(AmqpReceiveConsumerMock.Object);
 
-            MaskinportenClientMock.Setup(_ => _.GetAccessToken(It.IsAny<string>()))
-                                  .ReturnsAsync(new MaskinportenToken(_token, 100));
+            MaskinportenClientMock
+                .Setup(maskinportenClient => maskinportenClient.GetAccessToken(It.IsAny<string>()))
+                .ReturnsAsync(new MaskinportenToken(_token, 100));
+
+            // Mock the async ConsumerCancelledAsync invocation
+            AmqpReceiveConsumerMock
+                .SetupAdd(amqpReceiveConsumer => amqpReceiveConsumer.ConsumerCancelledAsync += It.IsAny<Func<ConsumerEventArgs, Task>>());
+
+            // Mock the async ReceivedAsync event subscription
+            AmqpReceiveConsumerMock
+                .SetupAdd(amqpReceiveConsumer => amqpReceiveConsumer.ReceivedAsync += It.IsAny<Func<MottattMeldingArgs, Task>>());
         }
 
         private IntegrasjonConfiguration CreateIntegrationConfiguration()

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Exceptions;
 using KS.Fiks.IO.Client.Models;
+using Microsoft.Extensions.Logging;
 using Moq;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -22,16 +24,21 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public void CreatesModelWhenConstructed()
+        public async Task CreatesConnectionAndChannelWhenConstructed()
         {
-            var sut = _fixture.CreateSutAsync();
+            var sut = await _fixture.CreateSutAsync().ConfigureAwait(false);
 
             _fixture.ConnectionFactoryMock.Verify(
-                factory =>
-                    factory.CreateConnectionAsync(
-                        It.IsAny<IList<AmqpTcpEndpoint>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<CancellationToken>()),
+                factory => factory.CreateConnectionAsync(
+                    It.IsAny<IList<AmqpTcpEndpoint>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            _fixture.ConnectionMock.Verify(
+                connection => connection.CreateChannelAsync(
+                    It.IsAny<CreateChannelOptions>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -59,9 +66,12 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
             await sut.AddMessageReceivedHandlerAsync(handler, cancelledHandler);
 
+            _fixture.ConnectionMock.Verify(
+                conn => conn.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+
             _fixture.AmqpConsumerFactoryMock.Verify(
-                consumerFactory =>
-                    consumerFactory.CreateReceiveConsumer(It.IsAny<IChannel>()),
+                consumerFactory => consumerFactory.CreateReceiveConsumer(It.IsAny<IChannel>()),
                 Times.Once);
         }
 
@@ -105,5 +115,118 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
             counter.ShouldBe(1);
         }
+
+        [Fact]
+        public async Task IsOpenAsyncReturnsTrueWhenConnectionAndChannelAreOpen()
+        {
+            _fixture.ConnectionMock.Setup(conn => conn.IsOpen).Returns(true);
+            _fixture.ChannelMock.Setup(channel => channel.IsOpen).Returns(true);
+
+            var sut = await _fixture.CreateSutAsync();
+
+            var result = await sut.IsOpenAsync();
+
+            result.ShouldBe(true);
+        }
+
+        [Fact]
+        public async Task IsOpenAsyncReturnsFalseWhenConnectionIsClosed()
+        {
+            _fixture.ConnectionMock.Setup(conn => conn.IsOpen).Returns(false);
+            _fixture.ChannelMock.Setup(channel => channel.IsOpen).Returns(true);
+
+            var sut = await _fixture.CreateSutAsync();
+
+            var result = await sut.IsOpenAsync();
+
+            result.ShouldBe(false);
+        }
+
+        [Fact]
+        public async Task IsOpenAsyncReturnsFalseWhenChannelIsClosed()
+        {
+            _fixture.ConnectionMock.Setup(conn => conn.IsOpen).Returns(true);
+            _fixture.ChannelMock.Setup(channel => channel.IsOpen).Returns(false);
+
+            var sut = await _fixture.CreateSutAsync();
+
+            var result = await sut.IsOpenAsync();
+
+            result.ShouldBe(false);
+        }
+
+        [Fact]
+        public async Task DisposeAsyncDisposesChannelAndConnection()
+        {
+            var sut = await _fixture.CreateSutAsync();
+
+            _fixture.ChannelMock.Setup(channel => channel.DisposeAsync()).Returns(ValueTask.CompletedTask);
+            _fixture.ConnectionMock.Setup(connection => connection.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+            await sut.DisposeAsync();
+
+            _fixture.ChannelMock.Verify(channel => channel.DisposeAsync(), Times.Once);
+            _fixture.ConnectionMock.Verify(connection => connection.DisposeAsync(), Times.Once);
+        }
+
+       [Fact]
+       public async Task DisposeAsyncUnsubscribesConnectionEvents()
+       {
+           var sut = await _fixture.CreateSutAsync();
+           var connectionMock = _fixture.ConnectionMock;
+
+           connectionMock
+               .SetupRemove(connection =>
+                   connection.ConnectionShutdownAsync -= It.IsAny<AsyncEventHandler<ShutdownEventArgs>>());
+
+           connectionMock
+               .SetupRemove(connection => connection.ConnectionBlockedAsync -=
+                   It.IsAny<AsyncEventHandler<ConnectionBlockedEventArgs>>());
+
+           connectionMock
+               .SetupRemove(connection =>
+                   connection.ConnectionUnblockedAsync -= It.IsAny<AsyncEventHandler<AsyncEventArgs>>());
+
+           connectionMock
+               .SetupRemove(connection =>
+                   connection.RecoverySucceededAsync -= It.IsAny<AsyncEventHandler<AsyncEventArgs>>());
+
+           connectionMock
+               .SetupRemove(connection => connection.RecoveringConsumerAsync -=
+                   It.IsAny<AsyncEventHandler<RecoveringConsumerEventArgs>>());
+
+           connectionMock
+               .SetupRemove(connection => connection.ConnectionRecoveryErrorAsync -=
+                   It.IsAny<AsyncEventHandler<ConnectionRecoveryErrorEventArgs>>());
+
+           await sut.DisposeAsync();
+
+           connectionMock.VerifyRemove(
+               connection => connection.ConnectionShutdownAsync -= It.IsAny<AsyncEventHandler<ShutdownEventArgs>>(),
+               Times.AtLeastOnce);
+
+           connectionMock.VerifyRemove(
+               connection => connection.ConnectionBlockedAsync -=
+                   It.IsAny<AsyncEventHandler<ConnectionBlockedEventArgs>>(),
+               Times.AtLeastOnce);
+
+           connectionMock.VerifyRemove(
+               connection => connection.ConnectionUnblockedAsync -= It.IsAny<AsyncEventHandler<AsyncEventArgs>>(),
+               Times.AtLeastOnce);
+
+           connectionMock.VerifyRemove(
+               connection => connection.RecoverySucceededAsync -= It.IsAny<AsyncEventHandler<AsyncEventArgs>>(),
+               Times.AtLeastOnce);
+
+           connectionMock.VerifyRemove(
+               connection => connection.RecoveringConsumerAsync -=
+                   It.IsAny<AsyncEventHandler<RecoveringConsumerEventArgs>>(),
+               Times.AtLeastOnce);
+
+           connectionMock.VerifyRemove(
+               connection => connection.ConnectionRecoveryErrorAsync -=
+                   It.IsAny<AsyncEventHandler<ConnectionRecoveryErrorEventArgs>>(),
+               Times.AtLeastOnce);
+       }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerFixture.cs
@@ -18,13 +18,13 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
     {
         private const string DokumentlagerHeaderName = "dokumentlager-id";
 
-        private Mock<IBasicProperties> _defaultProperties;
+        private Mock<IReadOnlyBasicProperties> _defaultProperties;
 
         private bool _shouldUseDokumentlager = false;
 
         public AmqpReceiveConsumerFixture()
         {
-            ModelMock = new Mock<IChannel>();
+            ChannelMock = new Mock<IChannel>();
             DokumentlagerHandler = new Mock<IDokumentlagerHandler>();
             FileWriterMock = new Mock<IFileWriter>();
             AsicDecrypterMock = new Mock<IAsicDecrypter>();
@@ -41,11 +41,11 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
         public Stream DokumentlagerOutStream => new MemoryStream();
 
-        public Mock<IChannel> ModelMock { get; }
+        public Mock<IChannel> ChannelMock { get; }
 
         public MottattMeldingMetadata DefaultMetadata { get; }
 
-        public IBasicProperties DefaultProperties => _defaultProperties.Object;
+        public IReadOnlyBasicProperties DefaultProperties => _defaultProperties.Object;
 
         public AmqpReceiveConsumerFixture WithDokumentlagerHeader()
         {
@@ -67,22 +67,23 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
         internal Mock<IDokumentlagerHandler> DokumentlagerHandler { get; }
 
-        internal AmqpReceiveConsumer CreateSut()
+        internal Task<AmqpReceiveConsumer> CreateSutAsync()
         {
             SetProperties();
             SetupMocks();
-            return new AmqpReceiveConsumer(
-                ModelMock.Object,
+            return Task.FromResult(new AmqpReceiveConsumer(
+                ChannelMock.Object,
                 DokumentlagerHandler.Object,
                 FileWriterMock.Object,
                 AsicDecrypterMock.Object,
                 SendHandlerMock.Object,
-                DefaultMetadata.MottakerKontoId);
+                DefaultMetadata.MottakerKontoId));
         }
 
         private void SetProperties()
         {
-            _defaultProperties = new Mock<IBasicProperties>();
+            _defaultProperties = new Mock<IReadOnlyBasicProperties>();
+
             var headers = new Dictionary<string, object>
             {
                 {"avsender-id", Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()) },
@@ -97,8 +98,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             }
 
             _defaultProperties.Setup(_ => _.Headers).Returns(headers);
-            _defaultProperties.Setup(_ => _.Expiration)
-                              .Returns(value: "100");
+            _defaultProperties.Setup(_ => _.Expiration).Returns("100");
         }
 
         private void SetupMocks()

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerFixture.cs
@@ -24,7 +24,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
         public AmqpReceiveConsumerFixture()
         {
-            ModelMock = new Mock<IModel>();
+            ModelMock = new Mock<IChannel>();
             DokumentlagerHandler = new Mock<IDokumentlagerHandler>();
             FileWriterMock = new Mock<IFileWriter>();
             AsicDecrypterMock = new Mock<IAsicDecrypter>();
@@ -41,7 +41,7 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
         public Stream DokumentlagerOutStream => new MemoryStream();
 
-        public Mock<IModel> ModelMock { get; }
+        public Mock<IChannel> ModelMock { get; }
 
         public MottattMeldingMetadata DefaultMetadata { get; }
 

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerTests.cs
@@ -432,10 +432,9 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
 
             var deliveryTag = (ulong)3423423;
 
-            Func<MottattMeldingArgs, Task> handler = messageArgs =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
-                messageArgs.SvarSender.Ack();
-                return Task.CompletedTask;
+                await messageArgs.SvarSender.AckAsync().ConfigureAwait(false);
             };
 
             sut.ReceivedAsync += handler;

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpReceiveConsumerTests.cs
@@ -3,39 +3,47 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Exceptions;
-using KS.Fiks.IO.Client.FileIO;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Client.Utility;
-using KS.Fiks.IO.Crypto.Asic;
 using Moq;
 using RabbitMQ.Client;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace KS.Fiks.IO.Client.Tests.Amqp
 {
     public class AmqpReceiveConsumerTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
         private AmqpReceiveConsumerFixture _fixture;
 
-        public AmqpReceiveConsumerTests()
+        public AmqpReceiveConsumerTests(ITestOutputHelper testOutputHelper)
         {
+            _testOutputHelper = testOutputHelper;
             _fixture = new AmqpReceiveConsumerFixture();
         }
 
         [Fact]
-        public void ReceivedHandler()
+        public async Task ReceivedHandlerAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
 
             var hasBeenCalled = false;
-            var handler = new EventHandler<MottattMeldingArgs>((a, _) => { hasBeenCalled = true; });
 
-            sut.Received += handler;
+            Func<MottattMeldingArgs, Task> handler = async args =>
+            {
+                hasBeenCalled = true;
+                await Task.CompletedTask.ConfigureAwait(false);
+            };
 
-            sut.HandleBasicDeliver(
+            sut.ReceivedAsync += handler;
+
+
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -48,40 +56,37 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public void ReceivesExpectedMessageMetadata()
+        public async Task ReceivesExpectedMessageMetadataAsync()
         {
             var expectedMessageMetadata = _fixture.DefaultMetadata;
 
             var headers = new Dictionary<string, object>
             {
-                {"avsender-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.AvsenderKontoId.ToString()) },
-                {"melding-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingId.ToString()) },
-                {"type", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingType) },
-                {"svar-til", Encoding.UTF8.GetBytes(expectedMessageMetadata.SvarPaMelding.ToString()) },
-                {ReceivedMessageParser.EgendefinertHeaderPrefix + "test", Encoding.UTF8.GetBytes("Test")}
+                { "avsender-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.AvsenderKontoId.ToString()) },
+                { "melding-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingId.ToString()) },
+                { "type", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingType) },
+                { "svar-til", Encoding.UTF8.GetBytes(expectedMessageMetadata.SvarPaMelding.ToString()) },
+                { ReceivedMessageParser.EgendefinertHeaderPrefix + "test", Encoding.UTF8.GetBytes("Test") }
             };
 
-            var propertiesMock = new Mock<IBasicProperties>();
+            var propertiesMock = new Mock<IReadOnlyBasicProperties>();
             propertiesMock.Setup(_ => _.Headers).Returns(headers);
             propertiesMock.Setup(_ => _.Expiration)
-                          .Returns(
-                              expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                .Returns(expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            var sut = _fixture.CreateSut();
-            IMottattMelding actualMelding = new MottattMelding(
-                true,
-                _fixture.DefaultMetadata,
-                () => Task.FromResult((Stream)new MemoryStream(new byte[1])),
-                Mock.Of<IAsicDecrypter>(),
-                Mock.Of<IFileWriter>());
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) =>
+            var sut = await _fixture.CreateSutAsync();
+
+            IMottattMelding actualMelding = null;
+
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 actualMelding = messageArgs.Melding;
-            });
+                await Task.CompletedTask.ConfigureAwait(false);
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -90,51 +95,49 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 propertiesMock.Object,
                 Array.Empty<byte>());
 
+            actualMelding.ShouldNotBeNull();
             actualMelding.MeldingId.ShouldBe(expectedMessageMetadata.MeldingId);
             actualMelding.MeldingType.ShouldBe(expectedMessageMetadata.MeldingType);
             actualMelding.MottakerKontoId.ShouldBe(expectedMessageMetadata.MottakerKontoId);
             actualMelding.AvsenderKontoId.ShouldBe(expectedMessageMetadata.AvsenderKontoId);
             actualMelding.SvarPaMelding.ShouldBe(expectedMessageMetadata.SvarPaMelding);
             actualMelding.Ttl.ShouldBe(expectedMessageMetadata.Ttl);
-            actualMelding.Headere["test"].ToString().ShouldBe("Test");
+            actualMelding.Headere["test"].ShouldBe("Test");
             actualMelding.Resendt.ShouldBeFalse();
         }
 
         [Fact]
-        public void ReceivesExpectedMessageMetadataWithRedeliveredTrue()
+        public async Task ReceivesExpectedMessageMetadataWithRedeliveredTrueAsync()
         {
             var expectedMessageMetadata = _fixture.DefaultMetadata;
 
             var headers = new Dictionary<string, object>
             {
-                {"avsender-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.AvsenderKontoId.ToString()) },
-                {"melding-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingId.ToString()) },
-                {"type", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingType) },
-                {"svar-til", Encoding.UTF8.GetBytes(expectedMessageMetadata.SvarPaMelding.ToString()) },
-                {ReceivedMessageParser.EgendefinertHeaderPrefix + "test", Encoding.UTF8.GetBytes("Test")}
+                { "avsender-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.AvsenderKontoId.ToString()) },
+                { "melding-id", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingId.ToString()) },
+                { "type", Encoding.UTF8.GetBytes(expectedMessageMetadata.MeldingType) },
+                { "svar-til", Encoding.UTF8.GetBytes(expectedMessageMetadata.SvarPaMelding.ToString()) },
+                { ReceivedMessageParser.EgendefinertHeaderPrefix + "test", Encoding.UTF8.GetBytes("Test") }
             };
 
-            var propertiesMock = new Mock<IBasicProperties>();
+            var propertiesMock = new Mock<IReadOnlyBasicProperties>();
             propertiesMock.Setup(_ => _.Headers).Returns(headers);
             propertiesMock.Setup(_ => _.Expiration)
-                          .Returns(
-                              expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                .Returns(expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            var sut = _fixture.CreateSut();
-            IMottattMelding actualMelding = new MottattMelding(
-                true,
-                _fixture.DefaultMetadata,
-                () => Task.FromResult((Stream)new MemoryStream(new byte[1])),
-                Mock.Of<IAsicDecrypter>(),
-                Mock.Of<IFileWriter>());
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) =>
+            var sut = await _fixture.CreateSutAsync();
+
+            IMottattMelding actualMelding = null;
+
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 actualMelding = messageArgs.Melding;
-            });
+                await Task.CompletedTask.ConfigureAwait(false);
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 true,
@@ -143,18 +146,19 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 propertiesMock.Object,
                 Array.Empty<byte>());
 
+            actualMelding.ShouldNotBeNull();
             actualMelding.MeldingId.ShouldBe(expectedMessageMetadata.MeldingId);
             actualMelding.MeldingType.ShouldBe(expectedMessageMetadata.MeldingType);
             actualMelding.MottakerKontoId.ShouldBe(expectedMessageMetadata.MottakerKontoId);
             actualMelding.AvsenderKontoId.ShouldBe(expectedMessageMetadata.AvsenderKontoId);
             actualMelding.SvarPaMelding.ShouldBe(expectedMessageMetadata.SvarPaMelding);
             actualMelding.Ttl.ShouldBe(expectedMessageMetadata.Ttl);
-            actualMelding.Headere["test"].ToString().ShouldBe("Test");
+            actualMelding.Headere["test"].ShouldBe("Test");
             actualMelding.Resendt.ShouldBeTrue();
         }
 
         [Fact]
-        public void ThrowsParseExceptionIfMessageIdIsNotValidGuid()
+        public async Task ThrowsParseExceptionIfMessageIdIsNotValidGuidAsync()
         {
             var expectedMessageMetadata = _fixture.DefaultMetadata;
 
@@ -166,59 +170,60 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 {"svar-til", Encoding.UTF8.GetBytes(expectedMessageMetadata.SvarPaMelding.ToString()) }
             };
 
-            var propertiesMock = new Mock<IBasicProperties>();
+            var propertiesMock = new Mock<IReadOnlyBasicProperties>();
             propertiesMock.Setup(_ => _.Headers).Returns(headers);
             propertiesMock.Setup(_ => _.Expiration)
-                          .Returns(
-                              expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                .Returns(expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            var sut = _fixture.CreateSut();
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) => { });
+            var sut = await _fixture.CreateSutAsync();
 
-            sut.Received += handler;
-            Assert.Throws<FiksIOParseException>(() =>
+            Func<MottattMeldingArgs, Task> handler = _ => Task.CompletedTask;
+
+            sut.ReceivedAsync += handler;
+
+            await Should.ThrowAsync<FiksIOParseException>(async () =>
             {
-                sut.HandleBasicDeliver(
+                await sut.HandleBasicDeliverAsync(
                     "tag",
                     34,
                     false,
                     "exchange",
                     expectedMessageMetadata.MottakerKontoId.ToString(),
                     propertiesMock.Object,
-                    Array.Empty<byte>());
+                    Array.Empty<byte>()).ConfigureAwait(false);
             });
         }
 
         [Fact]
-        public void ThrowsMissingHeaderExceptionExceptionIfHeaderIsNull()
+        public async Task ThrowsMissingHeaderExceptionIfHeaderIsNullAsync()
         {
             var expectedMessageMetadata = _fixture.DefaultMetadata;
 
             var propertiesMock = new Mock<IBasicProperties>();
             propertiesMock.Setup(_ => _.Headers).Returns((IDictionary<string, object>)null);
             propertiesMock.Setup(_ => _.Expiration)
-                          .Returns(
-                              expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                .Returns(expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            var sut = _fixture.CreateSut();
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) => { });
+            var sut = await _fixture.CreateSutAsync();
 
-            sut.Received += handler;
-            Assert.Throws<FiksIOMissingHeaderException>(() =>
+            Func<MottattMeldingArgs, Task> handler = _ => Task.CompletedTask;
+            sut.ReceivedAsync += handler;
+
+            await Should.ThrowAsync<FiksIOMissingHeaderException>(async () =>
             {
-                sut.HandleBasicDeliver(
+                await sut.HandleBasicDeliverAsync(
                     "tag",
                     34,
                     false,
                     "exchange",
                     expectedMessageMetadata.MottakerKontoId.ToString(),
                     propertiesMock.Object,
-                    Array.Empty<byte>());
+                    Array.Empty<byte>()).ConfigureAwait(false);
             });
         }
 
         [Fact]
-        public void ThrowsMissingHeaderExceptionExceptionIfMessageIdIsMissing()
+        public async Task ThrowsMissingHeaderExceptionIfMessageIdIsMissingAsync()
         {
             var expectedMessageMetadata = _fixture.DefaultMetadata;
 
@@ -232,42 +237,41 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
             var propertiesMock = new Mock<IBasicProperties>();
             propertiesMock.Setup(_ => _.Headers).Returns(headers);
             propertiesMock.Setup(_ => _.Expiration)
-                          .Returns(
-                              expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                .Returns(expectedMessageMetadata.Ttl.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            var sut = _fixture.CreateSut();
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) => { });
+            var sut = await _fixture.CreateSutAsync();
+            Func<MottattMeldingArgs, Task> handler = _ => Task.CompletedTask;
+            sut.ReceivedAsync += handler;
 
-            sut.Received += handler;
-            Assert.Throws<FiksIOMissingHeaderException>(() =>
+            await Should.ThrowAsync<FiksIOMissingHeaderException>(async () =>
             {
-                sut.HandleBasicDeliver(
+                await sut.HandleBasicDeliverAsync(
                     "tag",
                     34,
                     false,
                     "exchange",
                     expectedMessageMetadata.MottakerKontoId.ToString(),
                     propertiesMock.Object,
-                    Array.Empty<byte>());
+                    Array.Empty<byte>()).ConfigureAwait(false);
             });
         }
 
         [Fact]
-        public void FileWriterWriteIsCalledWhenWriteEncryptedZip()
+        public async Task FileWriterWriteIsCalledWhenWriteEncryptedZipAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
 
             var filePath = "/my/path/something.zip";
-            var data = new[] {default(byte) };
+            var data = new[] { default(byte) };
 
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
-                messageArgs.Melding.WriteEncryptedZip(filePath);
-            });
+                await messageArgs.Melding.WriteEncryptedZip(filePath).ConfigureAwait(false);
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -280,18 +284,18 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public void DokumentlagerHandlerIsUsedWhenHeaderIsSet()
+        public async Task DokumentlagerHandlerIsUsedWhenHeaderIsSetAsync()
         {
-            var sut = _fixture.WithDokumentlagerHeader().CreateSut();
+            var sut = await _fixture.WithDokumentlagerHeader().CreateSutAsync();
 
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
-                var stream = messageArgs.Melding.EncryptedStream;
-            });
+                await messageArgs.Melding.EncryptedStream.ConfigureAwait(false);
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -300,24 +304,24 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 null);
 
-            _fixture.DokumentlagerHandler.Verify(_ => _.Download(It.IsAny<Guid>()));
+            _fixture.DokumentlagerHandler.Verify(_ => _.Download(It.IsAny<Guid>()), Times.Once);
         }
 
         [Fact]
-        public void DokumentlagerHandlerIsNotUsedWhenHeaderIsNotSet()
+        public async Task DokumentlagerHandlerIsNotUsedWhenHeaderIsNotSetAsync()
         {
-            var sut = _fixture.WithoutDokumentlagerHeader().CreateSut();
+            var sut = await _fixture.WithoutDokumentlagerHeader().CreateSutAsync();
 
-            var data = new[] {default(byte) };
+            var data = new[] { default(byte) };
 
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
-                var stream = messageArgs.Melding.EncryptedStream;
-            });
+                await messageArgs.Melding.EncryptedStream.ConfigureAwait(false);
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -330,21 +334,21 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public async Task DataAsStreamIsReturnedWhenGettingEncryptedStream()
+        public async Task DataAsStreamIsReturnedWhenGettingEncryptedStreamAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
 
-            var data = new[] {default(byte), byte.MaxValue};
+            var data = new[] { default(byte), byte.MaxValue };
 
             Stream actualDataStream = new MemoryStream();
-            var handler = new EventHandler<MottattMeldingArgs>(async (a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 actualDataStream = await messageArgs.Melding.EncryptedStream.ConfigureAwait(false);
-            });
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -354,28 +358,28 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 data);
 
             var actualData = new byte[2];
-            await actualDataStream.ReadAsync(actualData, 0, 2).ConfigureAwait(false);
+            await actualDataStream.ReadAsync(actualData, 0, 2);
 
             actualData[0].ShouldBe(data[0]);
             actualData[1].ShouldBe(data[1]);
         }
 
         [Fact]
-        public async Task PayloadDecrypterDecryptIsCalledWhenGettingDecryptedStream()
+        public async Task PayloadDecrypterDecryptIsCalledWhenGettingDecryptedStreamAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
 
-            var data = new[] {default(byte), byte.MaxValue};
+            var data = new[] { default(byte), byte.MaxValue };
 
             Stream actualDataStream = new MemoryStream();
-            var handler = new EventHandler<MottattMeldingArgs>(async (a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 actualDataStream = await messageArgs.Melding.DecryptedStream.ConfigureAwait(false);
-            });
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -384,30 +388,31 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            _fixture.AsicDecrypterMock.Verify(_ => _.Decrypt(It.IsAny<Task<Stream>>()));
+            _fixture.AsicDecrypterMock.Verify(_ => _.Decrypt(It.IsAny<Task<Stream>>()), Times.Once);
 
             var actualData = new byte[2];
-            await actualDataStream.ReadAsync(actualData, 0, 2).ConfigureAwait(false);
+            await actualDataStream.ReadAsync(actualData, 0, 2);
+
             actualData[0].ShouldBe(data[0]);
             actualData[1].ShouldBe(data[1]);
         }
 
         [Fact]
-        public void PayloadDecrypterAndFileWriterIsCalledWhenWriteDecryptedFile()
+        public async Task PayloadDecrypterAndFileWriterIsCalledWhenWriteDecryptedFileAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
 
-            var data = new[] {default(byte), byte.MaxValue};
+            var data = new[] { default(byte), byte.MaxValue };
             var filePath = "/my/path/something.zip";
 
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
-                messageArgs.Melding.WriteDecryptedZip(filePath);
-            });
+                await messageArgs.Melding.WriteDecryptedZip(filePath).ConfigureAwait(false);
+            };
 
-            sut.Received += handler;
+            sut.ReceivedAsync += handler;
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -416,20 +421,26 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            _fixture.AsicDecrypterMock.Verify(_ => _.WriteDecrypted(It.IsAny<Task<Stream>>(), filePath));
+            _fixture.AsicDecrypterMock.Verify(_ => _.WriteDecrypted(It.IsAny<Task<Stream>>(), filePath), Times.Once);
         }
 
         [Fact]
-        public void BasicAckIsCalledFromReplySender()
+        public async Task BasicAckIsCalledFromReplySenderAsync()
         {
-            var sut = _fixture.CreateSut();
-            var data = new[] {default(byte), byte.MaxValue};
+            var sut = await _fixture.CreateSutAsync();
+            var data = new[] { default(byte), byte.MaxValue };
 
-            var handler = new EventHandler<MottattMeldingArgs>((a, messageArgs) => { messageArgs.SvarSender.Ack(); });
             var deliveryTag = (ulong)3423423;
 
-            sut.Received += handler;
-            sut.HandleBasicDeliver(
+            Func<MottattMeldingArgs, Task> handler = messageArgs =>
+            {
+                messageArgs.SvarSender.Ack();
+                return Task.CompletedTask;
+            };
+
+            sut.ReceivedAsync += handler;
+
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 deliveryTag,
                 false,
@@ -438,16 +449,16 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            _fixture.ModelMock.Verify(_ => _.BasicAck(deliveryTag, false));
+            _fixture.ChannelMock.Verify(_ => _.BasicAckAsync(deliveryTag, false, It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
-        public void BasicAckIsNotCalledWithDeliveryTagIfReceiverIsNotSet()
+        public async Task BasicAckIsNotCalledWithDeliveryTagIfReceiverIsNotSetAsync()
         {
-            var sut = _fixture.CreateSut();
-            var data = new[] {default(byte), byte.MaxValue};
+            var sut = await _fixture.CreateSutAsync();
+            var data = new[] { default(byte), byte.MaxValue };
 
-            sut.HandleBasicDeliver(
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 34,
                 false,
@@ -456,31 +467,35 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                 _fixture.DefaultProperties,
                 data);
 
-            _fixture.ModelMock.Verify(_ => _.BasicAck(It.IsAny<ulong>(), false), Times.Never);
+            _fixture.ChannelMock.Verify(
+                _ => _.BasicAckAsync(It.IsAny<ulong>(), false, It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
-        public void ThrowsExceptionWhenGettingEncryptedStreamWithNoData()
+        public async Task ThrowsExceptionWhenGettingEncryptedStreamWithNoDataAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
             var data = Array.Empty<byte>();
             var correctExceptionThrown = false;
 
-            var handler = new EventHandler<MottattMeldingArgs>(async (a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 try
                 {
-                    var stream = await messageArgs.Melding.EncryptedStream;
+                    var stream = await messageArgs.Melding.EncryptedStream.ConfigureAwait(false);
                 }
-                catch (FiksIOMissingDataException ex)
+                catch (FiksIOMissingDataException)
                 {
                     correctExceptionThrown = true;
                 }
-            });
-            var deliveryTag = (ulong) 3423423;
+            };
 
-            sut.Received += handler;
-            sut.HandleBasicDeliver(
+            var deliveryTag = (ulong)3423423;
+
+            sut.ReceivedAsync += handler;
+
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 deliveryTag,
                 false,
@@ -493,27 +508,29 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public void ThrowsExceptionWhenGettingDecryptedStreamWithNoData()
+        public async Task ThrowsExceptionWhenGettingDecryptedStreamWithNoDataAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
             var data = Array.Empty<byte>();
             var correctExceptionThrown = false;
 
-            var handler = new EventHandler<MottattMeldingArgs>(async (a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 try
                 {
-                    var stream = await messageArgs.Melding.DecryptedStream;
+                    var stream = await messageArgs.Melding.DecryptedStream.ConfigureAwait(false);
                 }
-                catch (FiksIOMissingDataException ex)
+                catch (FiksIOMissingDataException)
                 {
                     correctExceptionThrown = true;
                 }
-            });
-            var deliveryTag = (ulong) 3423423;
+            };
 
-            sut.Received += handler;
-            sut.HandleBasicDeliver(
+            var deliveryTag = (ulong)3423423;
+
+            sut.ReceivedAsync += handler;
+
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 deliveryTag,
                 false,
@@ -526,27 +543,29 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public void ThrowsExceptionWhenWritingDecryptedStreamWithNoData()
+        public async Task ThrowsExceptionWhenWritingDecryptedStreamWithNoDataAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
             var data = Array.Empty<byte>();
             var correctExceptionThrown = false;
 
-            var handler = new EventHandler<MottattMeldingArgs>(async (a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 try
                 {
                     await messageArgs.Melding.WriteDecryptedZip("out.zip").ConfigureAwait(false);
                 }
-                catch (FiksIOMissingDataException ex)
+                catch (FiksIOMissingDataException)
                 {
                     correctExceptionThrown = true;
                 }
-            });
-            var deliveryTag = (ulong) 3423423;
+            };
 
-            sut.Received += handler;
-            sut.HandleBasicDeliver(
+            var deliveryTag = (ulong)3423423;
+
+            sut.ReceivedAsync += handler;
+
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 deliveryTag,
                 false,
@@ -559,27 +578,29 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public void ThrowsExceptionWhenWritingEnryptedStreamWithNoData()
+        public async Task ThrowsExceptionWhenWritingEncryptedStreamWithNoDataAsync()
         {
-            var sut = _fixture.CreateSut();
+            var sut = await _fixture.CreateSutAsync();
             var data = Array.Empty<byte>();
             var correctExceptionThrown = false;
 
-            var handler = new EventHandler<MottattMeldingArgs>(async (a, messageArgs) =>
+            Func<MottattMeldingArgs, Task> handler = async messageArgs =>
             {
                 try
                 {
                     await messageArgs.Melding.WriteEncryptedZip("out.zip").ConfigureAwait(false);
                 }
-                catch (FiksIOMissingDataException ex)
+                catch (FiksIOMissingDataException)
                 {
                     correctExceptionThrown = true;
                 }
-            });
-            var deliveryTag = (ulong) 3423423;
+            };
 
-            sut.Received += handler;
-            sut.HandleBasicDeliver(
+            var deliveryTag = (ulong)3423423;
+
+            sut.ReceivedAsync += handler;
+
+            await sut.HandleBasicDeliverAsync(
                 "tag",
                 deliveryTag,
                 false,

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpWatcherTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpWatcherTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using KS.Fiks.IO.Client.Amqp;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Xunit;
+
+namespace KS.Fiks.IO.Client.Tests.Amqp
+{
+    public class DefaultAmqpWatcherTests
+    {
+        private readonly Mock<ILogger<DefaultAmqpWatcher>> _loggerMock;
+        private readonly DefaultAmqpWatcher _watcher;
+
+        public DefaultAmqpWatcherTests()
+        {
+            _loggerMock = new Mock<ILogger<DefaultAmqpWatcher>>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+
+            loggerFactoryMock
+                .Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                .Returns(_loggerMock.Object);
+
+            _watcher = new DefaultAmqpWatcher(loggerFactoryMock.Object);
+        }
+
+        [Fact]
+        public async Task HandleConnectionBlockedLogsWarning()
+        {
+            var eventArgs = new ConnectionBlockedEventArgs("Test reason");
+
+            await _watcher.HandleConnectionBlocked(this, eventArgs);
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Warning, "RabbitMQ Connection Blocked: Test reason", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleConnectionUnblockedLogsInformation()
+        {
+            await _watcher.HandleConnectionUnblocked(this, new AsyncEventArgs());
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Information, "RabbitMQ Connection Unblocked", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleConnectionShutdownLogsWarning()
+        {
+            var eventArgs = new ShutdownEventArgs(ShutdownInitiator.Peer, 0, "Shutdown occurred");
+
+            await _watcher.HandleConnectionShutdown(this, eventArgs);
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Warning, "RabbitMQ Connection Shutdown: Shutdown occurred", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleConnectionRecoveryErrorLogsError()
+        {
+            var exception = new Exception("Recovery error");
+
+            await _watcher.HandleConnectionRecoveryError(this, new ConnectionRecoveryErrorEventArgs(exception));
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Error, "RabbitMQ Connection Recovery Failed", exception, Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleRecoverySucceededLogsInformation()
+        {
+            await _watcher.HandleRecoverySucceeded(this, new AsyncEventArgs());
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Information, "RabbitMQ Connection Recovery Succeeded", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleRecoveringConsumerLogsInformation()
+        {
+            var consumerTag = "test-consumer";
+            var consumerArguments = new Dictionary<string, object>();
+            var eventArgs = new RecoveringConsumerEventArgs(consumerTag, consumerArguments, CancellationToken.None);
+
+            await _watcher.HandleRecoveringConsumer(this, eventArgs);
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Information, $"RabbitMQ Recovering Consumer: {consumerTag}", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleChannelShutdownLogsWarning()
+        {
+            var eventArgs = new ShutdownEventArgs(ShutdownInitiator.Library, 404, "Channel shutdown");
+
+            await _watcher.HandleChannelShutdown(this, eventArgs);
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Warning, "RabbitMQ Channel Shutdown: Channel shutdown", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleBasicChannelCancelLogsWarning()
+        {
+            await _watcher.HandleBasicChannelCancel("test-consumer");
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Warning, "RabbitMQ Consumer Cancelled: test-consumer", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleBasicChannelCancelOkLogsInformation()
+        {
+            await _watcher.HandleBasicChannelCancelOk("test-consumer");
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Information, "RabbitMQ Consumer Cancellation Acknowledged: test-consumer", Times.Once());
+        }
+
+        [Fact]
+        public async Task HandleBasicChannelConsumeOkLogsInformation()
+        {
+            await _watcher.HandleBasicChannelConsumeOk("test-consumer");
+
+            MockLoggerAssertions.VerifyLog(_loggerMock, LogLevel.Information, "RabbitMQ Consumer Successfully Started: test-consumer", Times.Once());
+        }
+    }
+
+    public static class MockLoggerAssertions
+    {
+        public static void VerifyLog<T>(Mock<ILogger<T>> mockLogger, LogLevel logLevel, string expectedMessage, Times times)
+        {
+            mockLogger.Verify(
+                x => x.Log(
+                    It.Is<LogLevel>(lvl => lvl == logLevel),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(expectedMessage, StringComparison.OrdinalIgnoreCase)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                times);
+        }
+
+        public static void VerifyLog<T>(
+            Mock<ILogger<T>> mockLogger,
+            LogLevel logLevel,
+            string expectedMessage,
+            Exception expectedException,
+            Times times)
+        {
+            mockLogger.Verify(
+                x => x.Log(
+                    logLevel,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(expectedMessage, StringComparison.OrdinalIgnoreCase)),
+                    It.Is<Exception>(ex => ex == expectedException),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                times);
+        }
+    }
+}

--- a/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderFixture.cs
@@ -1,45 +1,79 @@
 using System;
+using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Amqp;
 using KS.Fiks.IO.Send.Client.Configuration;
 using Ks.Fiks.Maskinporten.Client;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace KS.Fiks.IO.Client.Tests.Amqp
 {
     public class MaskinportenCredentialsProviderFixture
     {
-        private bool _connectionFactoryShouldThrow;
-        private bool _connectionShouldThrow;
         private string _firstToken = "firsttesttoken";
+        private string _newToken = "newValidToken";
         private Guid _integrationId = Guid.NewGuid();
         private string _integrationPassword = "defaultPassword";
         private int _expiresIn = 100;
+        private bool _shouldThrowException;
+        private ILoggerFactory _loggerFactory;
+        private bool _shouldTimeout;
 
-        internal Mock<IMaskinportenClient> MaskinportenClientMock { get; } = new Mock<IMaskinportenClient>();
+        public Guid IntegrationId => _integrationId;
+
+        public string IntegrationPassword => _integrationPassword;
+
+        public Mock<IMaskinportenClient> MaskinportenClientMock { get; } = new Mock<IMaskinportenClient>();
 
         internal MaskinportenCredentialsProvider CreateSut()
         {
-            var conf = new IntegrasjonConfiguration(_integrationId, _integrationPassword);
+            var conf = new IntegrasjonConfiguration(_integrationId, IntegrationPassword);
             SetupMocks();
-            var credentialsProvider = new MaskinportenCredentialsProvider("Test", MaskinportenClientMock.Object, conf);
 
-            return credentialsProvider;
+            return new MaskinportenCredentialsProvider(
+                "Test",
+                MaskinportenClientMock.Object,
+                conf,
+                _loggerFactory);
         }
 
         private void SetupMocks()
         {
-            MaskinportenClientMock.Setup(_ => _.GetAccessToken(It.IsAny<string>()))
-                                  .ReturnsAsync(new MaskinportenToken(_firstToken, _expiresIn));
+            if (_shouldThrowException)
+            {
+                MaskinportenClientMock
+                    .Setup(_ => _.GetAccessToken(It.IsAny<string>()))
+                    .ThrowsAsync(new Exception("Token retrieval failed"));
+            }
+            else if (_shouldTimeout)
+            {
+                MaskinportenClientMock
+                    .Setup(_ => _.GetAccessToken(It.IsAny<string>()))
+                    .Returns(async () =>
+                    {
+                        await Task.Delay(6000);
+                        return new MaskinportenToken(_firstToken, _expiresIn);
+                    });
+            }
+            else
+            {
+                MaskinportenClientMock
+                    .SetupSequence(_ => _.GetAccessToken(It.IsAny<string>()))
+                    .ReturnsAsync(new MaskinportenToken(_firstToken, _expiresIn)) 
+                    .ReturnsAsync(new MaskinportenToken(_newToken, 100));
+            }
         }
 
-        private IntegrasjonConfiguration CreateIntegrationConfiguration()
-        {
-            return new IntegrasjonConfiguration(_integrationId, _integrationPassword);
-        }
-
-        public MaskinportenCredentialsProviderFixture WithMaskinportenToken(string token)
+        public MaskinportenCredentialsProviderFixture WithMaskinportenToken(string token, int expiresIn = 100)
         {
             _firstToken = token;
+            _expiresIn = expiresIn;
+            return this;
+        }
+
+        public MaskinportenCredentialsProviderFixture WithNewToken(string token)
+        {
+            _newToken = token;
             return this;
         }
 
@@ -52,6 +86,24 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         public MaskinportenCredentialsProviderFixture WithTokenExpiresIn(int expiresIn)
         {
             _expiresIn = expiresIn;
+            return this;
+        }
+
+        public MaskinportenCredentialsProviderFixture WithTokenRetrievalException()
+        {
+            _shouldThrowException = true;
+            return this;
+        }
+
+        public MaskinportenCredentialsProviderFixture WithTokenRetrievalTimeout()
+        {
+            _shouldTimeout = true;
+            return this;
+        }
+
+        public MaskinportenCredentialsProviderFixture WithLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
             return this;
         }
     }

--- a/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/MaskinportenCredentialsProviderTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace KS.Fiks.IO.Client.Tests.Amqp
@@ -12,12 +14,57 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
         }
 
         [Fact]
-        public void PasswordIsSetToIntegrationPasswordAndMaskinportenToken()
+        public async Task PasswordIsSetToIntegrationPasswordAndMaskinportenTokenAsync()
+        {
+            var password = "myIntegrationPassword";
+            var token = "maskinportenExpectedToken";
+
+            var sut = _fixture
+                .WithMaskinportenToken(token)
+                .WithIntegrationPassword(password)
+                .CreateSut();
+
+            var credentials = await sut.GetCredentialsAsync();
+
+            Assert.Equal($"{password} {token}", credentials.Password);
+        }
+
+        [Fact]
+        public async Task GetCredentialsAsync_ShouldHandleExceptionsGracefully()
+        {
+            var sut = _fixture.WithTokenRetrievalException().CreateSut();
+
+            await Assert.ThrowsAsync<Exception>(() => sut.GetCredentialsAsync());
+        }
+
+        [Fact]
+        public async Task ExpiredToken_ShouldRequestNewTokenAsync()
+        {
+            var expiredToken = "expiredToken";
+            var newToken = "newValidToken";
+
+            var sut = _fixture
+                .WithMaskinportenToken(expiredToken, -10)
+                .WithNewToken(newToken)
+                .CreateSut();
+            await sut.GetCredentialsAsync();
+
+            var credentials = await sut.GetCredentialsAsync();
+
+            Assert.Equal($"{_fixture.IntegrationPassword} {newToken}", credentials.Password);
+        }
+
+        [Fact]
+        public async Task GetCredentialsAsync_ReturnsCorrectCredentials()
         {
             var password = "myIntegrationPassword";
             var token = "maskinportenExpectedToken";
             var sut = _fixture.WithMaskinportenToken(token).WithIntegrationPassword(password).CreateSut();
-            Assert.Equal($"{password} {token}", sut.Password);
+
+            var credentials = await sut.GetCredentialsAsync();
+
+            Assert.Equal($"{password} {token}", credentials.Password);
+            Assert.Equal(_fixture.IntegrationId.ToString(), credentials.UserName);
         }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Amqp;
 using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Client.Dokumentlager;
@@ -154,9 +155,10 @@ namespace KS.Fiks.IO.Client.Tests
             CatalogHandlerMock.Setup(_ => _.Lookup(It.IsAny<LookupRequest>())).ReturnsAsync(_lookupReturn);
             SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IList<IPayload>>()))
                            .ReturnsAsync(_sendtMeldingReturn);
-            AmqpHandlerMock.Setup(_ => _.AddMessageReceivedHandler(
-                It.IsAny<EventHandler<MottattMeldingArgs>>(),
-                It.IsAny<EventHandler<ConsumerEventArgs>>()));
+            AmqpHandlerMock.Setup(_ => _.AddMessageReceivedHandlerAsync(
+                    It.IsAny<Func<MottattMeldingArgs, Task>>(),
+                    It.IsAny<Func<ConsumerEventArgs, Task>>()))
+                .Returns(Task.CompletedTask);
         }
 
         private void SetupConfiguration(bool withMaskinportenConfig)

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
@@ -175,29 +175,28 @@ namespace KS.Fiks.IO.Client.Tests
         }
 
         [Fact]
-        public void NewSubscriptionCallsAmqpHandlerWithOnReceived()
+        public async Task NewSubscriptionAsyncCallsAmqpHandlerWithOnlyOnReceived()
         {
             var sut = _fixture.CreateSut();
 
-            var onReceived = new EventHandler<MottattMeldingArgs>((a, b) => { });
+            var onReceived = new Func<MottattMeldingArgs, Task>(msg => Task.CompletedTask);
 
-            sut.NewSubscription(onReceived);
+            await sut.NewSubscriptionAsync(onReceived);
 
-            _fixture.AmqpHandlerMock.Verify(_ => _.AddMessageReceivedHandler(onReceived, null));
+            _fixture.AmqpHandlerMock.Verify(_ => _.AddMessageReceivedHandlerAsync(onReceived, It.IsAny<Func<ConsumerEventArgs, Task>>()), Times.Once);
         }
 
         [Fact]
-        public void NewSubscriptionCallsAmqpHandlerWithOnReceivedAndOnCanceled()
+        public async Task NewSubscriptionAsyncCallsAmqpHandlerWithOnReceivedAndOnCanceled()
         {
             var sut = _fixture.CreateSut();
 
-            var onReceived = new EventHandler<MottattMeldingArgs>((a, b) => { });
+            var onReceived = new Func<MottattMeldingArgs, Task>(msg => Task.CompletedTask);
+            var onCanceled = new Func<ConsumerEventArgs, Task>(args => Task.CompletedTask);
 
-            var onCanceled = new EventHandler<ConsumerEventArgs>((a, b) => { });
+            await sut.NewSubscriptionAsync(onReceived, onCanceled);
 
-            sut.NewSubscription(onReceived, onCanceled);
-
-            _fixture.AmqpHandlerMock.Verify(_ => _.AddMessageReceivedHandler(onReceived, onCanceled));
+            _fixture.AmqpHandlerMock.Verify(_ => _.AddMessageReceivedHandlerAsync(onReceived, onCanceled), Times.Once);
         }
 
         [Fact]

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -24,7 +24,7 @@
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
-        <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+        <PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
         <PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/KS.Fiks.IO.Client.Tests/Send/SvarSenderFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SvarSenderFixture.cs
@@ -15,17 +15,17 @@ namespace KS.Fiks.IO.Client.Tests.Send
     {
         private MottattMelding _mottattMelding;
 
-        private Action _ack;
-        private Action _nack;
-        private Action _nackWithRequeue;
+        private Func<Task> _ack;
+        private Func<Task> _nack;
+        private Func<Task> _nackWithRequeue;
 
         public SvarSenderFixture()
         {
             SendHandlerMock = new Mock<ISendHandler>();
             _mottattMelding = null;
-            _ack = Mock.Of<Action>();
-            _nack = Mock.Of<Action>();
-            _nackWithRequeue = Mock.Of<Action>();
+            _ack = Mock.Of<Func<Task>>();
+            _nack = Mock.Of<Func<Task>>();
+            _nackWithRequeue = Mock.Of<Func<Task>>();
         }
 
         public SvarSenderFixture WithMottattMelding(MottattMelding mottattMelding)
@@ -34,19 +34,19 @@ namespace KS.Fiks.IO.Client.Tests.Send
             return this;
         }
 
-        public SvarSenderFixture WithAck(Action ack)
+        public SvarSenderFixture WithAck(Func<Task> ack)
         {
             _ack = ack;
             return this;
         }
 
-        public SvarSenderFixture WithNack(Action nack)
+        public SvarSenderFixture WithNack(Func<Task> nack)
         {
             this._nack = nack;
             return this;
         }
 
-        public SvarSenderFixture WithNackRequeue(Action nackRequeue)
+        public SvarSenderFixture WithNackRequeue(Func<Task> nackRequeue)
         {
             this._nackWithRequeue = nackRequeue;
             return this;

--- a/KS.Fiks.IO.Client/Amqp/AmqpConnectionManager.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpConnectionManager.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using KS.Fiks.IO.Client.Configuration;
+using KS.Fiks.IO.Client.Exceptions;
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+
+namespace KS.Fiks.IO.Client.Amqp
+{
+    public class AmqpConnectionManager
+    {
+        private readonly IConnectionFactory _connectionFactory;
+        private readonly SslOption? _sslOption;
+        private readonly SemaphoreSlim _tokenBucket;
+        private readonly int _bucketSize;
+        private readonly TimeSpan _tokenFillRate;
+        private readonly ILogger _logger;
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+
+        public AmqpConnectionManager(
+            IConnectionFactory connectionFactory,
+            AmqpConfiguration amqpConfiguration,
+            int bucketSize = 5,
+            TimeSpan? tokenFillRate = null,
+            ILoggerFactory loggerFactory = null)
+        {
+            _connectionFactory = connectionFactory;
+            _sslOption = amqpConfiguration.SslOption;
+            _bucketSize = bucketSize;
+            _tokenFillRate = tokenFillRate ?? TimeSpan.FromSeconds(1);
+            _tokenBucket = new SemaphoreSlim(bucketSize, bucketSize);
+            _logger = loggerFactory?.CreateLogger("AmqpConnectionManager");
+
+            if (!string.IsNullOrEmpty(amqpConfiguration.Vhost))
+            {
+                _connectionFactory.VirtualHost = amqpConfiguration.Vhost;
+                _logger?.LogInformation("Set VirtualHost to {Vhost}", amqpConfiguration.Vhost);
+            }
+
+            _logger?.LogInformation("Initializing AmqpConnectionManager with bucketSize={BucketSize} and tokenFillRate={TokenFillRate}", _bucketSize, _tokenFillRate);
+            StartTokenRefill();
+        }
+
+        private void StartTokenRefill()
+        {
+            _logger?.LogInformation("Starting token refill process");
+            Task.Run(
+                async () =>
+            {
+                while (!_cancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    await Task.Delay(_tokenFillRate, _cancellationTokenSource.Token).ConfigureAwait(false);
+                    if (_tokenBucket.CurrentCount >= _bucketSize)
+                    {
+                        continue;
+                    }
+
+                    _tokenBucket.Release();
+                    _logger?.LogDebug("Token refilled. Current token count: {CurrentCount}/{BucketSize}", _tokenBucket.CurrentCount, _bucketSize);
+                }
+            }, _cancellationTokenSource.Token);
+        }
+
+        public void StopTokenRefill()
+        {
+            _cancellationTokenSource.Cancel();
+            _logger?.LogInformation("Token refill process stopped");
+        }
+
+        public async Task<IConnection> CreateConnectionAsync(AmqpConfiguration configuration)
+        {
+            try
+            {
+                _logger?.LogInformation("Waiting for token to create connection");
+                await _tokenBucket.WaitAsync().ConfigureAwait(false);
+                _logger?.LogDebug("Token acquired, proceeding to create connection");
+
+                var endpoint = new AmqpTcpEndpoint(configuration.Host, configuration.Port, _sslOption);
+                var connection = await _connectionFactory
+                    .CreateConnectionAsync(new List<AmqpTcpEndpoint> { endpoint }, configuration.ApplicationName)
+                    .ConfigureAwait(false);
+                _logger?.LogInformation("Successfully created connection to {Host}:{Port}", configuration.Host, configuration.Port);
+                return connection;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to create connection to {Host}:{Port}", configuration.Host, configuration.Port);
+                throw new FiksIOAmqpConnectionFailedException($"Failed to create connection to {configuration.Host}:{configuration.Port}", ex);
+            }
+        }
+    }
+}

--- a/KS.Fiks.IO.Client/Amqp/AmqpConsumerFactory.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpConsumerFactory.cs
@@ -34,7 +34,7 @@ namespace KS.Fiks.IO.Client.Amqp
             _accountId = kontoConfiguration.KontoId;
         }
 
-        public IAmqpReceiveConsumer CreateReceiveConsumer(IModel channel)
+        public IAmqpReceiveConsumer CreateReceiveConsumer(IChannel channel)
         {
             return new AmqpReceiveConsumer(channel, _dokumentlagerHandler, _fileWriter, _decrypter, _sendHandler, _accountId);
         }

--- a/KS.Fiks.IO.Client/Amqp/AmqpConsumerFactory.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpConsumerFactory.cs
@@ -19,11 +19,14 @@ namespace KS.Fiks.IO.Client.Amqp
 
         private readonly IDokumentlagerHandler _dokumentlagerHandler;
 
+        private readonly IAmqpWatcher _amqpWatcher;
+
         private readonly Guid _accountId;
 
         public AmqpConsumerFactory(
             ISendHandler sendHandler,
             IDokumentlagerHandler dokumentlagerHandler,
+            IAmqpWatcher amqpWatcher,
             KontoConfiguration kontoConfiguration)
         {
             _dokumentlagerHandler = dokumentlagerHandler;
@@ -31,12 +34,13 @@ namespace KS.Fiks.IO.Client.Amqp
             _decrypter = new AsicDecrypter(DecryptionService.Create(kontoConfiguration.PrivatNokler));
 
             _sendHandler = sendHandler;
+            _amqpWatcher = amqpWatcher;
             _accountId = kontoConfiguration.KontoId;
         }
 
         public IAmqpReceiveConsumer CreateReceiveConsumer(IChannel channel)
         {
-            return new AmqpReceiveConsumer(channel, _dokumentlagerHandler, _fileWriter, _decrypter, _sendHandler, _accountId);
+            return new AmqpReceiveConsumer(channel, _dokumentlagerHandler, _fileWriter, _decrypter, _sendHandler, _amqpWatcher, _accountId);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -52,7 +52,6 @@ namespace KS.Fiks.IO.Client.Amqp
                 _connectionFactory.VirtualHost = amqpConfiguration.Vhost;
             }
 
-            _amqpConsumerFactory = consumerFactory ?? new AmqpConsumerFactory(sendHandler, dokumentlagerHandler, _kontoConfiguration);
 
             if (loggerFactory != null)
             {
@@ -60,6 +59,8 @@ namespace KS.Fiks.IO.Client.Amqp
             }
 
             _amqpWatcher = amqpWatcher ?? new DefaultAmqpWatcher(loggerFactory);
+
+            _amqpConsumerFactory = consumerFactory ?? new AmqpConsumerFactory(sendHandler, dokumentlagerHandler, _amqpWatcher, _kontoConfiguration);
         }
 
         public static async Task<IAmqpHandler> CreateAsync(

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -136,14 +136,25 @@ namespace KS.Fiks.IO.Client.Amqp
 
         public async ValueTask DisposeAsync()
         {
-            if (_connection is { IsOpen: true })
+            try
             {
-                _connection.ConnectionShutdownAsync -= _amqpWatcher.HandleConnectionShutdown;
-                _connection.ConnectionBlockedAsync -= _amqpWatcher.HandleConnectionBlocked;
-                _connection.ConnectionUnblockedAsync -= _amqpWatcher.HandleConnectionUnblocked;
+                if (_connection is { IsOpen: true })
+                {
+                    _connection.ConnectionShutdownAsync -= _amqpWatcher.HandleConnectionShutdown;
+                    _connection.ConnectionBlockedAsync -= _amqpWatcher.HandleConnectionBlocked;
+                    _connection.ConnectionUnblockedAsync -= _amqpWatcher.HandleConnectionUnblocked;
 
-                await _channel.DisposeAsync().ConfigureAwait(false);
-                await _connection.DisposeAsync().ConfigureAwait(false);
+                    if (_channel != null)
+                    {
+                        await _channel.DisposeAsync().ConfigureAwait(false);
+                    }
+
+                    await _connection.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error disposing AmqpHandler resources.");
             }
         }
 

--- a/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Dokumentlager;
 using KS.Fiks.IO.Client.Exceptions;
@@ -9,98 +10,133 @@ using KS.Fiks.IO.Client.Send;
 using KS.Fiks.IO.Client.Utility;
 using KS.Fiks.IO.Crypto.Asic;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
-    internal class AmqpReceiveConsumer : DefaultBasicConsumer, IAmqpReceiveConsumer
+    internal class AmqpReceiveConsumer : IAsyncBasicConsumer, IAmqpReceiveConsumer
     {
         private const string DokumentlagerHeaderName = "dokumentlager-id";
 
         private readonly Guid _accountId;
-
         private readonly IAsicDecrypter _decrypter;
-
         private readonly IDokumentlagerHandler _dokumentlagerHandler;
-
         private readonly IFileWriter _fileWriter;
-
         private readonly ISendHandler _sendHandler;
 
         public AmqpReceiveConsumer(
-            IModel model,
+            IChannel model,
             IDokumentlagerHandler dokumentlagerHandler,
             IFileWriter fileWriter,
             IAsicDecrypter decrypter,
             ISendHandler sendHandler,
             Guid accountId)
-            : base(model)
         {
-            this._dokumentlagerHandler = dokumentlagerHandler;
-            this._fileWriter = fileWriter;
-            this._decrypter = decrypter;
-            this._sendHandler = sendHandler;
-            this._accountId = accountId;
+            Channel = model;
+            _dokumentlagerHandler = dokumentlagerHandler;
+            _fileWriter = fileWriter;
+            _decrypter = decrypter;
+            _sendHandler = sendHandler;
+            _accountId = accountId;
         }
+
+        public IChannel Channel { get; }
 
         public event EventHandler<MottattMeldingArgs> Received;
 
-        public override void HandleBasicDeliver(
+        public async Task HandleBasicCancelAsync(string consumerTag, CancellationToken cancellationToken = default)
+        {
+            Console.WriteLine($"Consumer {consumerTag} was cancelled.");
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        public async Task HandleBasicCancelOkAsync(string consumerTag, CancellationToken cancellationToken = default)
+        {
+            Console.WriteLine($"Consumer {consumerTag} cancellation acknowledged.");
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        public async Task HandleBasicConsumeOkAsync(string consumerTag, CancellationToken cancellationToken = default)
+        {
+            Console.WriteLine($"Consumer {consumerTag} has started consuming messages.");
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        async Task IAsyncBasicConsumer.HandleBasicDeliverAsync(
             string consumerTag,
             ulong deliveryTag,
             bool redelivered,
             string exchange,
             string routingKey,
-            IBasicProperties properties,
-            ReadOnlyMemory<byte> body)
+            IReadOnlyBasicProperties properties,
+            ReadOnlyMemory<byte> body,
+            CancellationToken cancellationToken)
         {
-            base.HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
-
-            if (Received == null)
-            {
-                return;
-            }
-
             try
             {
                 var receivedMessage = ParseMessage(properties, body, redelivered);
 
+                async Task AckMessageAsync()
+                {
+                    if (Channel != null)
+                    {
+                        await Channel.BasicAckAsync(deliveryTag, false, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                async Task NackMessageAsync()
+                {
+                    if (Channel != null)
+                    {
+                        await Channel.BasicNackAsync(deliveryTag, false, false, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                }
+
+                async Task RequeueMessageAsync()
+                {
+                    if (Channel != null)
+                    {
+                        await Channel.BasicNackAsync(deliveryTag, false, true, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                var acknowledgeManager = new AmqpAcknowledgeManager(
+                    AckMessageAsync,
+                    NackMessageAsync,
+                    RequeueMessageAsync);
+
+                var svarSender = new SvarSender(
+                    _sendHandler,
+                    receivedMessage,
+                    acknowledgeManager);
+
+                var mottattMeldingArgs = new MottattMeldingArgs(
+                    receivedMessage,
+                    svarSender);
+
                 Received?.Invoke(
                     this,
-                    new MottattMeldingArgs(receivedMessage, new SvarSender(_sendHandler, receivedMessage, new AmqpAcknowledgeManager(() => Model.BasicAck(deliveryTag, false), () => Model.BasicNack(deliveryTag, false, false), () => Model.BasicNack(deliveryTag, false, true)))));
+                    mottattMeldingArgs);
             }
             catch (Exception ex)
             {
                 Console.WriteLine(ex.Message);
                 throw;
             }
+
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
-        private static bool IsDataInDokumentlager(IBasicProperties properties)
+        public async Task HandleChannelShutdownAsync(object channel, ShutdownEventArgs reason)
         {
-            return ReceivedMessageParser.GetGuidFromHeader(properties.Headers, DokumentlagerHeaderName) != null;
+            Console.WriteLine($"Channel shutdown: {reason.Cause}");
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
-        private static Guid GetDokumentlagerId(IBasicProperties properties)
+        private MottattMelding ParseMessage(IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body, bool resendt)
         {
-            try
-            {
-                return ReceivedMessageParser.RequireGuidFromHeader(properties.Headers, DokumentlagerHeaderName);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-                throw;
-            }
-        }
-
-        private static bool HasPayload(IBasicProperties properties, ReadOnlyMemory<byte> body)
-        {
-            return IsDataInDokumentlager(properties) || body.Length > 0;
-        }
-
-        private MottattMelding ParseMessage(IBasicProperties properties, ReadOnlyMemory<byte> body, bool resendt)
-        {
-            var metadata = ReceivedMessageParser.Parse(this._accountId, properties, resendt);
+            var metadata = ReceivedMessageParser.Parse(_accountId, properties, resendt);
             return new MottattMelding(
                 HasPayload(properties, body),
                 metadata,
@@ -109,7 +145,17 @@ namespace KS.Fiks.IO.Client.Amqp
                 _fileWriter);
         }
 
-        private Func<Task<Stream>> GetDataProvider(IBasicProperties properties, byte[] body)
+        private static bool HasPayload(IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        {
+            return IsDataInDokumentlager(properties) || body.Length > 0;
+        }
+
+        private static bool IsDataInDokumentlager(IReadOnlyBasicProperties properties)
+        {
+            return ReceivedMessageParser.GetGuidFromHeader(properties.Headers, DokumentlagerHeaderName) != null;
+        }
+
+        private Func<Task<Stream>> GetDataProvider(IReadOnlyBasicProperties properties, byte[] body)
         {
             if (!HasPayload(properties, body))
             {
@@ -118,10 +164,15 @@ namespace KS.Fiks.IO.Client.Amqp
 
             if (IsDataInDokumentlager(properties))
             {
-                return async () => await this._dokumentlagerHandler.Download(GetDokumentlagerId(properties));
+                return async () => await _dokumentlagerHandler.Download(GetDokumentlagerId(properties));
             }
 
             return async () => await Task.FromResult(new MemoryStream(body));
+        }
+
+        private static Guid GetDokumentlagerId(IReadOnlyBasicProperties properties)
+        {
+            return ReceivedMessageParser.RequireGuidFromHeader(properties.Headers, DokumentlagerHeaderName);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
@@ -51,7 +51,8 @@ namespace KS.Fiks.IO.Client.Amqp
         {
             if (ConsumerCancelledAsync != null)
             {
-                await ConsumerCancelledAsync.Invoke(new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);            }
+                await ConsumerCancelledAsync.Invoke(new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);
+            }
         }
 
         public async Task HandleBasicCancelOkAsync(string consumerTag, CancellationToken cancellationToken = default)
@@ -145,7 +146,8 @@ namespace KS.Fiks.IO.Client.Amqp
             await Task.CompletedTask.ConfigureAwait(false);
         }
 
-        private MottattMelding ParseMessage(IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body, bool resendt)
+        private MottattMelding ParseMessage(IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body,
+            bool resendt)
         {
             var metadata = ReceivedMessageParser.Parse(_accountId, properties, resendt);
             return new MottattMelding(
@@ -175,7 +177,8 @@ namespace KS.Fiks.IO.Client.Amqp
 
             if (IsDataInDokumentlager(properties))
             {
-                return async () => await _dokumentlagerHandler.Download(GetDokumentlagerId(properties)).ConfigureAwait(false);
+                return async () =>
+                    await _dokumentlagerHandler.Download(GetDokumentlagerId(properties)).ConfigureAwait(false);
             }
 
             return async () => await Task.FromResult<Stream>(new MemoryStream(body)).ConfigureAwait(false);

--- a/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
@@ -1,8 +1,9 @@
-﻿namespace KS.Fiks.IO.Client.Amqp
-{
-    using System;
-    using Microsoft.Extensions.Logging;
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client.Events;
 
+namespace KS.Fiks.IO.Client.Amqp
+{
     internal class DefaultAmqpWatcher : IAmqpWatcher
     {
         private readonly ILogger<DefaultAmqpWatcher> _logger;
@@ -15,19 +16,22 @@
             }
         }
 
-        public void HandleConnectionBlocked(object sender, EventArgs e)
+        public async Task HandleConnectionBlocked(object sender, ConnectionBlockedEventArgs connectionBlockedEventArgs)
         {
-            _logger?.LogDebug("RabbitMQ Connection ConnectionBlocked event has been triggered");
+            _logger?.LogDebug($"RabbitMQ Connection Blocked: {connectionBlockedEventArgs.Reason}");
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
-        public void HandleConnectionUnblocked(object sender, EventArgs e)
+        public async Task HandleConnectionUnblocked(object sender, AsyncEventArgs asyncEventArgs)
         {
-            _logger?.LogDebug("RabbitMQ Connection ConnectionUnblocked event has been triggered");
+            _logger?.LogDebug("RabbitMQ Connection Unblocked");
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
-        public void HandleConnectionShutdown(object sender, EventArgs shutdownEventArgs)
+        public async Task HandleConnectionShutdown(object sender, ShutdownEventArgs eventArgs)
         {
-            _logger?.LogDebug($"RabbitMQ Connection ConnectionShutdown event has been triggered");
+            _logger?.LogDebug($"RabbitMQ Connection Shutdown: {eventArgs.ReplyText}");
+            await Task.CompletedTask.ConfigureAwait(false);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
@@ -16,22 +16,22 @@ namespace KS.Fiks.IO.Client.Amqp
             }
         }
 
-        public async Task HandleConnectionBlocked(object sender, ConnectionBlockedEventArgs connectionBlockedEventArgs)
+        public Task HandleConnectionBlocked(object sender, ConnectionBlockedEventArgs connectionBlockedEventArgs)
         {
             _logger?.LogDebug($"RabbitMQ Connection Blocked: {connectionBlockedEventArgs.Reason}");
-            await Task.CompletedTask.ConfigureAwait(false);
+            return Task.CompletedTask;
         }
 
-        public async Task HandleConnectionUnblocked(object sender, AsyncEventArgs asyncEventArgs)
+        public Task HandleConnectionUnblocked(object sender, AsyncEventArgs asyncEventArgs)
         {
             _logger?.LogDebug("RabbitMQ Connection Unblocked");
-            await Task.CompletedTask.ConfigureAwait(false);
+            return Task.CompletedTask;
         }
 
-        public async Task HandleConnectionShutdown(object sender, ShutdownEventArgs eventArgs)
+        public Task HandleConnectionShutdown(object sender, ShutdownEventArgs eventArgs)
         {
             _logger?.LogDebug($"RabbitMQ Connection Shutdown: {eventArgs.ReplyText}");
-            await Task.CompletedTask.ConfigureAwait(false);
+            return Task.CompletedTask;
         }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
@@ -16,6 +16,7 @@ namespace KS.Fiks.IO.Client.Amqp
             }
         }
 
+        // Connection events
         public Task HandleConnectionBlocked(object sender, ConnectionBlockedEventArgs connectionBlockedEventArgs)
         {
             _logger?.LogWarning($"RabbitMQ Connection Blocked: {connectionBlockedEventArgs.Reason}");
@@ -30,7 +31,7 @@ namespace KS.Fiks.IO.Client.Amqp
 
         public Task HandleConnectionShutdown(object sender, ShutdownEventArgs eventArgs)
         {
-            _logger?.LogError($"RabbitMQ Connection Shutdown: {eventArgs.ReplyText}");
+            _logger?.LogWarning($"RabbitMQ Connection Shutdown: {eventArgs.ReplyText}");
             return Task.CompletedTask;
         }
 
@@ -49,6 +50,31 @@ namespace KS.Fiks.IO.Client.Amqp
         public Task HandleRecoveringConsumer(object sender, RecoveringConsumerEventArgs recoveringConsumerEvent)
         {
             _logger?.LogInformation($"RabbitMQ Recovering Consumer: {recoveringConsumerEvent.ConsumerTag}");
+            return Task.CompletedTask;
+        }
+
+        // Consumer events
+        public Task HandleChannelShutdown(object sender, ShutdownEventArgs eventArgs)
+        {
+            _logger?.LogWarning($"RabbitMQ Channel Shutdown: {eventArgs.ReplyText}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleBasicChannelCancel(string consumerTag)
+        {
+            _logger?.LogWarning($"RabbitMQ Consumer Cancelled: {consumerTag}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleBasicChannelCancelOk(string consumerTag)
+        {
+            _logger?.LogInformation($"RabbitMQ Consumer Cancellation Acknowledged: {consumerTag}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleBasicChannelConsumeOk(string consumerTag)
+        {
+            _logger?.LogInformation($"RabbitMQ Consumer Successfully Started: {consumerTag}");
             return Task.CompletedTask;
         }
     }

--- a/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/DefaultAmqpWatcher.cs
@@ -18,19 +18,37 @@ namespace KS.Fiks.IO.Client.Amqp
 
         public Task HandleConnectionBlocked(object sender, ConnectionBlockedEventArgs connectionBlockedEventArgs)
         {
-            _logger?.LogDebug($"RabbitMQ Connection Blocked: {connectionBlockedEventArgs.Reason}");
+            _logger?.LogWarning($"RabbitMQ Connection Blocked: {connectionBlockedEventArgs.Reason}");
             return Task.CompletedTask;
         }
 
         public Task HandleConnectionUnblocked(object sender, AsyncEventArgs asyncEventArgs)
         {
-            _logger?.LogDebug("RabbitMQ Connection Unblocked");
+            _logger?.LogInformation("RabbitMQ Connection Unblocked");
             return Task.CompletedTask;
         }
 
         public Task HandleConnectionShutdown(object sender, ShutdownEventArgs eventArgs)
         {
-            _logger?.LogDebug($"RabbitMQ Connection Shutdown: {eventArgs.ReplyText}");
+            _logger?.LogError($"RabbitMQ Connection Shutdown: {eventArgs.ReplyText}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleConnectionRecoveryError(object sender, ConnectionRecoveryErrorEventArgs eventArgs)
+        {
+            _logger?.LogError(eventArgs.Exception, "RabbitMQ Connection Recovery Failed");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleRecoverySucceeded(object sender, AsyncEventArgs eventArgs)
+        {
+            _logger?.LogInformation("RabbitMQ Connection Recovery Succeeded");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleRecoveringConsumer(object sender, RecoveringConsumerEventArgs recoveringConsumerEvent)
+        {
+            _logger?.LogInformation($"RabbitMQ Recovering Consumer: {recoveringConsumerEvent.ConsumerTag}");
             return Task.CompletedTask;
         }
     }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpAcknowledgeManager.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpAcknowledgeManager.cs
@@ -1,57 +1,43 @@
 using System;
+using System.Threading.Tasks;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
     public interface IAmqpAcknowledgeManager
     {
-        Action Ack();
+        Func<Task> Ack();
 
-        Action Nack();
+        Func<Task> Nack();
 
-        Action NackWithRequeue();
+        Func<Task> NackWithRequeue();
     }
 
     public class AmqpAcknowledgeManager : IAmqpAcknowledgeManager
     {
-        private readonly Action _ackAction;
-        private readonly Action _nackAction;
-        private readonly Action _nackWithRequeueAction;
+        private readonly Func<Task> _ackAction;
+        private readonly Func<Task> _nackAction;
+        private readonly Func<Task> _nackWithRequeueAction;
 
-        public AmqpAcknowledgeManager(Action ackAction, Action nackAction, Action nackWithRequeueAction)
+        public AmqpAcknowledgeManager(Func<Task> ackAction, Func<Task> nackAction, Func<Task> nackWithRequeueAction)
         {
-            this._ackAction = ackAction;
-            this._nackAction = nackAction;
-            this._nackWithRequeueAction = nackWithRequeueAction;
+            _ackAction = ackAction ?? throw new ArgumentNullException(nameof(ackAction));
+            _nackAction = nackAction ?? throw new ArgumentNullException(nameof(nackAction));
+            _nackWithRequeueAction = nackWithRequeueAction ?? throw new ArgumentNullException(nameof(nackWithRequeueAction));
         }
 
-        public Action Ack()
+        public Func<Task> Ack()
         {
-            if (this._ackAction == null)
-            {
-                throw new NotSupportedException("Ack is currently not supported");
-            }
-
-            return this._ackAction;
+            return _ackAction;
         }
 
-        public Action Nack()
+        public Func<Task> Nack()
         {
-            if (this._nackAction == null)
-            {
-                throw new NotSupportedException("Nack is currently not supported");
-            }
-
-            return this._nackAction;
+            return _nackAction;
         }
 
-        public Action NackWithRequeue()
+        public Func<Task> NackWithRequeue()
         {
-            if (this._nackWithRequeueAction == null)
-            {
-                throw new NotSupportedException("Nack is currently not supported");
-            }
-
-            return this._nackWithRequeueAction;
+            return _nackWithRequeueAction;
         }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpAcknowledgeManager.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpAcknowledgeManager.cs
@@ -5,11 +5,11 @@ namespace KS.Fiks.IO.Client.Amqp
 {
     public interface IAmqpAcknowledgeManager
     {
-        Func<Task> Ack();
+        Task AckAsync();
 
-        Func<Task> Nack();
+        Task NackAsync();
 
-        Func<Task> NackWithRequeue();
+        Task NackWithRequeueAsync();
     }
 
     public class AmqpAcknowledgeManager : IAmqpAcknowledgeManager
@@ -20,24 +20,24 @@ namespace KS.Fiks.IO.Client.Amqp
 
         public AmqpAcknowledgeManager(Func<Task> ackAction, Func<Task> nackAction, Func<Task> nackWithRequeueAction)
         {
-            _ackAction = ackAction ?? throw new ArgumentNullException(nameof(ackAction));
-            _nackAction = nackAction ?? throw new ArgumentNullException(nameof(nackAction));
-            _nackWithRequeueAction = nackWithRequeueAction ?? throw new ArgumentNullException(nameof(nackWithRequeueAction));
+            _ackAction = ackAction;
+            _nackAction = nackAction;
+            _nackWithRequeueAction = nackWithRequeueAction;
         }
 
-        public Func<Task> Ack()
+        public async Task AckAsync()
         {
-            return _ackAction;
+            await _ackAction.Invoke().ConfigureAwait(false);
         }
 
-        public Func<Task> Nack()
+        public async Task NackAsync()
         {
-            return _nackAction;
+            await _nackAction.Invoke().ConfigureAwait(false);
         }
 
-        public Func<Task> NackWithRequeue()
+        public async Task NackWithRequeueAsync()
         {
-            return _nackWithRequeueAction;
+            await _nackWithRequeueAction.Invoke().ConfigureAwait(false);
         }
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpConsumerFactory.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpConsumerFactory.cs
@@ -4,6 +4,6 @@ namespace KS.Fiks.IO.Client.Amqp
 {
     internal interface IAmqpConsumerFactory
     {
-        IAmqpReceiveConsumer CreateReceiveConsumer(IModel channel);
+        IAmqpReceiveConsumer CreateReceiveConsumer(IChannel channel);
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
@@ -5,17 +5,11 @@ using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
-    public interface IAmqpHandler : IDisposable
+    public interface IAmqpHandler : IAsyncDisposable
     {
-        void AddMessageReceivedHandler(
-            EventHandler<MottattMeldingArgs> receivedEvent,
-            EventHandler<ConsumerEventArgs> cancelledEvent);
-
         Task AddMessageReceivedHandlerAsync(
             Func<MottattMeldingArgs, Task> receivedEvent,
             Func<ConsumerEventArgs, Task> cancelledEvent);
-
-        bool IsOpen();
 
         Task<bool> IsOpenAsync();
     }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Models;
 using RabbitMQ.Client.Events;
 
@@ -10,6 +11,12 @@ namespace KS.Fiks.IO.Client.Amqp
             EventHandler<MottattMeldingArgs> receivedEvent,
             EventHandler<ConsumerEventArgs> cancelledEvent);
 
+        Task AddMessageReceivedHandlerAsync(
+            Func<MottattMeldingArgs, Task> receivedEvent,
+            Func<ConsumerEventArgs, Task> cancelledEvent);
+
         bool IsOpen();
+
+        Task<bool> IsOpenAsync();
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpReceiveConsumer.cs
@@ -6,7 +6,7 @@ using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
-    public interface IAmqpReceiveConsumer : IAsyncBasicConsumer
+    internal interface IAmqpReceiveConsumer : IAsyncBasicConsumer
     {
         event Func<MottattMeldingArgs, Task> ReceivedAsync;
 

--- a/KS.Fiks.IO.Client/Amqp/IAmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpReceiveConsumer.cs
@@ -1,11 +1,15 @@
 using System;
+using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Models;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
-    internal interface IAmqpReceiveConsumer : IAsyncBasicConsumer
+    public interface IAmqpReceiveConsumer : IAsyncBasicConsumer
     {
-        event EventHandler<MottattMeldingArgs> Received;
+        event Func<MottattMeldingArgs, Task> ReceivedAsync;
+
+        event Func<ConsumerEventArgs, Task> ConsumerCancelledAsync;
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpReceiveConsumer.cs
@@ -4,7 +4,7 @@ using RabbitMQ.Client;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
-    internal interface IAmqpReceiveConsumer : IBasicConsumer
+    internal interface IAmqpReceiveConsumer : IAsyncBasicConsumer
     {
         event EventHandler<MottattMeldingArgs> Received;
     }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
@@ -16,5 +16,13 @@ namespace KS.Fiks.IO.Client.Amqp
         Task HandleRecoverySucceeded(object sender, AsyncEventArgs eventArgs);
 
         Task HandleRecoveringConsumer(object sender, RecoveringConsumerEventArgs recoveringConsumerEvent);
+
+        Task HandleChannelShutdown(object sender, ShutdownEventArgs eventArgs);
+
+        Task HandleBasicChannelCancel(string consumerTag);
+
+        Task HandleBasicChannelCancelOk(string consumerTag);
+
+        Task HandleBasicChannelConsumeOk(string consumerTag);
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client.Amqp

--- a/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
@@ -10,5 +10,11 @@ namespace KS.Fiks.IO.Client.Amqp
         Task HandleConnectionShutdown(object sender, ShutdownEventArgs eventArgs);
 
         Task HandleConnectionUnblocked(object sender, AsyncEventArgs asyncEventArgs);
+
+        Task HandleConnectionRecoveryError(object sender, ConnectionRecoveryErrorEventArgs eventArgs);
+
+        Task HandleRecoverySucceeded(object sender, AsyncEventArgs eventArgs);
+
+        Task HandleRecoveringConsumer(object sender, RecoveringConsumerEventArgs recoveringConsumerEvent);
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
+++ b/KS.Fiks.IO.Client/Amqp/IAmqpWatcher.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Threading.Tasks;
+using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
     public interface IAmqpWatcher
     {
-        void HandleConnectionBlocked(object sender, EventArgs e);
-        void HandleConnectionShutdown(object sender, EventArgs shutdownEventArgs);
-        void HandleConnectionUnblocked(object sender, EventArgs e);
+        Task HandleConnectionBlocked(object sender, ConnectionBlockedEventArgs connectionBlockedEventArgs);
+
+        Task HandleConnectionShutdown(object sender, ShutdownEventArgs eventArgs);
+
+        Task HandleConnectionUnblocked(object sender, AsyncEventArgs asyncEventArgs);
     }
 }

--- a/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
+++ b/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
@@ -25,8 +25,8 @@ namespace KS.Fiks.IO.Client.Amqp
             ILoggerFactory loggerFactory = null)
         {
             Name = name;
-            _maskinportenClient = maskinportenClient ?? throw new ArgumentNullException(nameof(maskinportenClient));
-            _integrasjonConfiguration = integrasjonConfiguration ?? throw new ArgumentNullException(nameof(integrasjonConfiguration));
+            _maskinportenClient = maskinportenClient;
+            _integrasjonConfiguration = integrasjonConfiguration;
             _logger = loggerFactory?.CreateLogger<MaskinportenCredentialsProvider>();
         }
 
@@ -143,7 +143,6 @@ namespace KS.Fiks.IO.Client.Amqp
 
             if (disposing)
             {
-                // Dispose managed resources if needed
                 _lock.ReleaseLock();
             }
 

--- a/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
+++ b/KS.Fiks.IO.Client/Amqp/MaskinportenCredentialsProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Send.Client.Configuration;
 using Ks.Fiks.Maskinporten.Client;
 using Microsoft.Extensions.Logging;
@@ -9,24 +8,36 @@ using RabbitMQ.Client;
 
 namespace KS.Fiks.IO.Client.Amqp
 {
-    public class MaskinportenCredentialsProvider : ICredentialsProvider
+    public sealed class MaskinportenCredentialsProvider : ICredentialsProvider, IDisposable
     {
-        private const int TokenRetrievalTimeout = 5000;
+        private const int TokenRetrievalTimeout = 5000; // 5 seconds timeout
         private static ILogger<MaskinportenCredentialsProvider> _logger;
         private readonly IMaskinportenClient _maskinportenClient;
         private readonly IntegrasjonConfiguration _integrasjonConfiguration;
-        private ReaderWriterLock _lock = new ReaderWriterLock();
+        private readonly ReaderWriterLock _lock = new ReaderWriterLock();
         private MaskinportenToken _maskinportenToken;
+        private bool _disposed;
 
-        public MaskinportenCredentialsProvider(string name, IMaskinportenClient maskinportenClient, IntegrasjonConfiguration integrasjonConfiguration, ILoggerFactory loggerFactory = null)
+        public MaskinportenCredentialsProvider(
+            string name,
+            IMaskinportenClient maskinportenClient,
+            IntegrasjonConfiguration integrasjonConfiguration,
+            ILoggerFactory loggerFactory = null)
         {
             Name = name;
-            _maskinportenClient = maskinportenClient;
-            _integrasjonConfiguration = integrasjonConfiguration;
-            if (loggerFactory != null)
-            {
-                _logger = loggerFactory.CreateLogger<MaskinportenCredentialsProvider>();
-            }
+            _maskinportenClient = maskinportenClient ?? throw new ArgumentNullException(nameof(maskinportenClient));
+            _integrasjonConfiguration = integrasjonConfiguration ?? throw new ArgumentNullException(nameof(integrasjonConfiguration));
+            _logger = loggerFactory?.CreateLogger<MaskinportenCredentialsProvider>();
+        }
+
+        public async Task<Credentials> GetCredentialsAsync(CancellationToken cancellationToken = default)
+        {
+            _logger?.LogDebug("Retrieving credentials asynchronously");
+
+            var token = await RetrieveTokenAsync(cancellationToken).ConfigureAwait(false);
+            var password = $"{_integrasjonConfiguration.IntegrasjonPassord} {token.Token}";
+
+            return new Credentials(Name, UserName, password, ValidUntil);
         }
 
         public string Name { get; }
@@ -35,51 +46,124 @@ namespace KS.Fiks.IO.Client.Amqp
 
         public string Password => $"{_integrasjonConfiguration.IntegrasjonPassord} {CheckState().Token}";
 
-        public TimeSpan? ValidUntil { get; }
+        private TimeSpan? ValidUntil => _maskinportenToken != null
+            ? _maskinportenToken.IsExpiring()
+                ? TimeSpan.Zero
+                : (TimeSpan?)(RequestNewTokenAfterTime - DateTime.UtcNow)
+            : null;
 
         public void Refresh()
         {
-            _logger.LogDebug("Refresh start");
-            RetrieveToken();
+            _logger?.LogDebug("Refresh start");
+            _ = RetrieveTokenAsync(CancellationToken.None).GetAwaiter().GetResult();
         }
 
         private MaskinportenToken CheckState()
         {
-            _lock.AcquireReaderLock(TokenRetrievalTimeout);
             try
             {
-                if (_maskinportenToken != null && !_maskinportenToken.IsExpiring())
+                _lock.AcquireReaderLock(TokenRetrievalTimeout);
+                try
                 {
-                    return _maskinportenToken;
+                    if (_maskinportenToken != null && !_maskinportenToken.IsExpiring())
+                    {
+                        return _maskinportenToken;
+                    }
+                }
+                finally
+                {
+                    _lock.ReleaseReaderLock();
                 }
             }
-            finally
+            catch (ApplicationException ex)
             {
-                _lock.ReleaseReaderLock();
+                _logger?.LogError(ex, "Timeout while acquiring read lock");
             }
 
-            return RetrieveToken();
+            return RequestOrRenewToken();
         }
 
-        private MaskinportenToken RetrieveToken()
+        private async Task<MaskinportenToken> RetrieveTokenAsync(CancellationToken cancellationToken)
         {
-            _lock.AcquireWriterLock(TokenRetrievalTimeout);
             try
             {
-                return RequestOrRenewToken();
+                _lock.AcquireWriterLock(TokenRetrievalTimeout);
+                try
+                {
+                    _logger?.LogDebug("Requesting or renewing Maskinporten token asynchronously");
+                    _maskinportenToken = await _maskinportenClient
+                        .GetAccessToken(_integrasjonConfiguration.Scope)
+                        .ConfigureAwait(false);
+                    return _maskinportenToken;
+                }
+                finally
+                {
+                    _lock.ReleaseWriterLock();
+                }
             }
-            finally
+            catch (ApplicationException ex)
             {
-                _lock.ReleaseReaderLock();
+                _logger?.LogError(ex, "Timeout while acquiring write lock");
+                throw;
             }
         }
 
         private MaskinportenToken RequestOrRenewToken()
         {
-            var getAccessTokenTask = Task.Run(() => _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope));
-            getAccessTokenTask.Wait();
-            _maskinportenToken = getAccessTokenTask.Result;
-            return _maskinportenToken;
+            try
+            {
+                _lock.AcquireWriterLock(TokenRetrievalTimeout);
+                try
+                {
+                    _logger?.LogDebug("Requesting or renewing Maskinporten token synchronously");
+                    _maskinportenToken = _maskinportenClient
+                        .GetAccessToken(_integrasjonConfiguration.Scope)
+                        .GetAwaiter()
+                        .GetResult();
+                    return _maskinportenToken;
+                }
+                finally
+                {
+                    _lock.ReleaseWriterLock();
+                }
+            }
+            catch (ApplicationException ex)
+            {
+                _logger?.LogError(ex, "Timeout while acquiring write lock");
+                throw;
+            }
         }
+
+        private void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // Dispose managed resources if needed
+                _lock.ReleaseLock();
+            }
+
+            _disposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~MaskinportenCredentialsProvider()
+        {
+            Dispose(false);
+        }
+
+        private DateTime RequestNewTokenAfterTime =>
+            _maskinportenToken != null && !_maskinportenToken.IsExpiring()
+                ? DateTime.UtcNow.AddSeconds(30)
+                : DateTime.UtcNow;
     }
 }

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -30,6 +30,8 @@ namespace KS.Fiks.IO.Client
 {
     public class FiksIOClient : IFiksIOClient
     {
+        private readonly ICatalogHandler _catalogHandler;
+
         private ISendHandler _sendHandler;
 
         private ILoggerFactory _loggerFactory;
@@ -39,8 +41,6 @@ namespace KS.Fiks.IO.Client
         private IDokumentlagerHandler _dokumentlagerHandler;
 
         private IMaskinportenClient _maskinportenClient;
-
-        private readonly ICatalogHandler _catalogHandler;
 
         private FiksIOClient(
             FiksIOConfiguration configuration,
@@ -134,10 +134,11 @@ namespace KS.Fiks.IO.Client
             return client;
         }
 
-        private async Task InitializeAmqpHandlerAsync(FiksIOConfiguration configuration,
+        private async Task InitializeAmqpHandlerAsync(
+            FiksIOConfiguration configuration,
             IAmqpWatcher amqpWatcher = null)
         {
-            _amqpHandler = _amqpHandler ?? await AmqpHandler.CreateAsync(
+            _amqpHandler ??= await AmqpHandler.CreateAsync(
                 _maskinportenClient,
                 _sendHandler,
                 _dokumentlagerHandler,

--- a/KS.Fiks.IO.Client/IFiksIOClient.cs
+++ b/KS.Fiks.IO.Client/IFiksIOClient.cs
@@ -9,7 +9,7 @@ using RabbitMQ.Client.Events;
 
 namespace KS.Fiks.IO.Client
 {
-    public interface IFiksIOClient : IDisposable
+    public interface IFiksIOClient : IAsyncDisposable
     {
         Guid KontoId { get; }
 
@@ -29,10 +29,8 @@ namespace KS.Fiks.IO.Client
 
         Task<SendtMelding> Send(MeldingRequest request, Stream payload, string filename);
 
-        void NewSubscription(EventHandler<MottattMeldingArgs> onMottattMelding);
+        Task NewSubscriptionAsync(Func<MottattMeldingArgs, Task> onMottattMelding, Func<ConsumerEventArgs, Task> onCanceled = null);
 
-        void NewSubscription(EventHandler<MottattMeldingArgs> onMottattMelding, EventHandler<ConsumerEventArgs> onCanceled);
-
-        bool IsOpen();
+        Task<bool> IsOpenAsync();
     }
 }

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -45,7 +45,7 @@
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.2" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-		<PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+		<PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/KS.Fiks.IO.Client/Send/ISvarSender.cs
+++ b/KS.Fiks.IO.Client/Send/ISvarSender.cs
@@ -20,18 +20,18 @@ namespace KS.Fiks.IO.Client.Send
         Task<SendtMelding> Svar(string meldingType, Guid? klientMeldingId = default);
 
         /**
-         * Acknowledges that the message has been consumed
-         */
-        void Ack();
+        * Acknowledges that the message has been consumed
+        */
+        Task AckAsync();
 
         /**
-         * Acknowledges that the message could not be consumed
-         */
-        void Nack();
+        * Acknowledges that the message could not be consumed
+        */
+        Task NackAsync();
 
         /**
-         *  Acknowledges that the message could not be consumed right and puts it back in the queue to be consumed again
-         */
-        void NackWithRequeue();
+        * Acknowledges that the message could not be consumed right and puts it back in the queue to be consumed again
+       */
+        Task NackWithRequeueAsync();
     }
 }

--- a/KS.Fiks.IO.Client/Send/SvarSender.cs
+++ b/KS.Fiks.IO.Client/Send/SvarSender.cs
@@ -52,19 +52,19 @@ namespace KS.Fiks.IO.Client.Send
                 .ConfigureAwait(false);
         }
 
-        public void Ack()
+        public async Task AckAsync()
         {
-            this._amqpAcknowledgeManager.Ack().Invoke();
+            await _amqpAcknowledgeManager.AckAsync().ConfigureAwait(false);
         }
 
-        public void Nack()
+        public async Task NackAsync()
         {
-            this._amqpAcknowledgeManager.Nack().Invoke();
+            await _amqpAcknowledgeManager.NackAsync().ConfigureAwait(false);
         }
 
-        public void NackWithRequeue()
+        public async Task NackWithRequeueAsync()
         {
-            this._amqpAcknowledgeManager.NackWithRequeue().Invoke();
+            await _amqpAcknowledgeManager.NackWithRequeueAsync().ConfigureAwait(false);
         }
 
         private async Task<SendtMelding> Reply(string messageType, IPayload payload, Guid? klientMeldingId)

--- a/KS.Fiks.IO.Client/Utility/ReceivedMessageParser.cs
+++ b/KS.Fiks.IO.Client/Utility/ReceivedMessageParser.cs
@@ -24,7 +24,7 @@ namespace KS.Fiks.IO.Client.Utility
 
         internal static MottattMeldingMetadata Parse(
             Guid receiverAccountId,
-            IBasicProperties properties,
+            IReadOnlyBasicProperties properties,
             bool resendt)
         {
             var headers = properties?.Headers;


### PR DESCRIPTION
**Dette er gjort:**

- RabbitMQ client bumpet fra 6.8.1 -> 7.1.1 (se [docs](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/main/v7-MIGRATION.md) for migrering)
- RabbitMQ sitt API og interne funksjoner er blitt asynkron og følger `[Task asynchronous programming model (TAP)](https://learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/)

- Hele RabbitMQ integrasjonen er nå fullstendig asynkron og funksjoner er endret.
- EventHandlere erstattet med asynkrone Func<_, Task>
- HandleBasicDeliverAsync introduseres og implementeres fra IAsyncBasicConsumer
- IDisposable -> IAsyncDisposable
- Dispose metoder er nå asynkrone
- AmqpReceiveConsumer tar inn amqpWacher og gir mer logging
- Rate-limiting i AmqpConnectionManager (med token bucket algoritme)
- Oppdatert tester og skrevet flere tester hvor det manglet dekning.

🔹 Breaking Changes:
🚨 Denne oppdateringen er ikke bakoverkompatibel. Konsumenter må oppdatere:

  - NewSubscription() → await NewSubscriptionAsync()
  - IsOpen() → await IsOpenAsync()
  - Dispose() → await DisposeAsync()
  - CreateAsync() → må nå alltid kalles med await.
  - Event-handlere må endres fra void til async Task.