### PR TITLE
Lagt til klientKorrelasjonsId som optional parameter

### DIFF
--- a/ExampleApplication/.gitignore
+++ b/ExampleApplication/.gitignore
@@ -40,3 +40,6 @@ appsettings.Development.json
 appsettings.Development.original.json
 appsettings.Test.json
 appsettings.Test2.json
+appsettings.Test3.json
+appsettings.Test4.json
+appsettings.Test5.json

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -31,14 +31,17 @@
       <Content Update="testfile.txt">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
-      <!--None Remove="appsettings.Development.json" />
+      <None Remove="appsettings.Development.json" />
       <Content Include="appsettings.Development.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
       <None Remove="appsettings.Test.json" />
       <Content Include="appsettings.Test.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content-->
+      </Content>
+      <Content Update="testfile.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
 

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -35,10 +35,6 @@
       <Content Include="appsettings.Development.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
-      <None Remove="appsettings.Test.json" />
-      <Content Include="appsettings.Test.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
     </ItemGroup>
   
     <ItemGroup>

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -31,10 +31,6 @@
       <Content Update="testfile.txt">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
-      <None Remove="appsettings.Development.json" />
-      <Content Include="appsettings.Development.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
     </ItemGroup>
   
     <ItemGroup>

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -39,12 +39,8 @@
       <Content Include="appsettings.Test.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
-      <Content Update="testfile.xml">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
     </ItemGroup>
-
-
+  
     <ItemGroup>
       <None Remove="testfile.txt" />
       <Content Include="testfile.txt">

--- a/ExampleApplication/FiksIO/FiksIOSubscriber.cs
+++ b/ExampleApplication/FiksIO/FiksIOSubscriber.cs
@@ -40,9 +40,10 @@ namespace ExampleApplication.FiksIO
             Log.Information("FiksIOSubscriber - Received a message with messagetype '{MessageType}' with following attributes: " +
                             "\n\t messageId : {MeldingId}" +
                             "\n\t klientMeldingId : {KlientMeldingId}" +
+                            "\n\t klientKorrelasjonsId : {KlientKorrelasjonsId}" +
                             "\n\t svarPaMelding : {SvarPaMelding}" + 
                             "\n\t fiksOrgNavn : {FiksOrgNavn}" , 
-                receivedMeldingType, mottatt.Melding.MeldingId, mottatt.Melding.KlientMeldingId, mottatt.Melding.SvarPaMelding, konto.FiksOrgNavn);
+                receivedMeldingType, mottatt.Melding.MeldingId, mottatt.Melding.KlientMeldingId, mottatt.Melding.KlientKorrelasjonsId, mottatt.Melding.SvarPaMelding, konto.FiksOrgNavn);
             
             switch (receivedMeldingType)
             {
@@ -57,7 +58,7 @@ namespace ExampleApplication.FiksIO
                     var klientMeldingId = Guid.NewGuid();
                     var sendtMelding = await mottatt.SvarSender.Svar(Program.FiksIOPong, klientMeldingId);
                     var payloadTxt = await GetDecryptedPayloadTxt(mottatt);
-                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId}", sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId);
+                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId} and klientKorrelasjonsId: {KlientKorrelasjonsId}", sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId, sendtMelding.KlientKorrelasjonsId);
                     break;
                 }
                 case Program.FiksArkivPing:
@@ -65,7 +66,7 @@ namespace ExampleApplication.FiksIO
                     var klientMeldingId = Guid.NewGuid();
                     var sendtMelding = await mottatt.SvarSender.Svar(Program.FiksArkivPong, klientMeldingId);
                     var payloadTxt = await GetDecryptedPayloadTxt(mottatt);
-                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId}", sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId);
+                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId} and klientKorrelasjonsId: {KlientKorrelasjonsId}", sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId, sendtMelding.KlientKorrelasjonsId);
                     break;
                 }
                 case Program.FiksPlanPing:
@@ -73,7 +74,7 @@ namespace ExampleApplication.FiksIO
                     var klientMeldingId = Guid.NewGuid();
                     var sendtMelding = await mottatt.SvarSender.Svar(Program.FiksPlanPong, klientMeldingId);
                     var payloadTxt = await GetDecryptedPayloadTxt(mottatt);
-                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId}", sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId);
+                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId} and klientKorrelasjonsId: {KlientKorrelasjonsId}", sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId, sendtMelding.KlientKorrelasjonsId);
                     break;
                 }
                 case Program.FiksMatrikkelfoeringPing:
@@ -81,7 +82,7 @@ namespace ExampleApplication.FiksIO
                     var klientMeldingId = Guid.NewGuid();
                     var sendtMelding = await mottatt.SvarSender.Svar(Program.FiksMatrikkelfoeringPong, klientMeldingId);
                     var payloadTxt = await GetDecryptedPayloadTxt(mottatt);
-                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId}",sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId);
+                    Log.Information("FiksIOSubscriber - Received {receivedMeldingType} with payload text {payload}. Replied messagetype 'ping' with messagetype 'pong' with messageId : {MeldingId} and klientMeldingId: {KlientMeldingId} and klientKorrelasjonsId: {KlientKorrelasjonsId}",sendtMelding.MeldingType, payloadTxt, sendtMelding.MeldingId, sendtMelding.KlientMeldingId, sendtMelding.KlientKorrelasjonsId);
                     break;
                 }
             }

--- a/ExampleApplication/FiksIO/MessageSender.cs
+++ b/ExampleApplication/FiksIO/MessageSender.cs
@@ -26,9 +26,10 @@ public class MessageSender
         try
         {
             var klientMeldingId = Guid.NewGuid();
-            Log.Information("MessageSender - sending messagetype {MessageType} to account id: {AccountId} with klientMeldingId {KlientMeldingId}", messageType, toAccountId, klientMeldingId);
+            var klientKorrelasjonsId = Guid.NewGuid().ToString();
+            Log.Information("MessageSender - sending messagetype {MessageType} to account id {AccountId} with klientMeldingId {KlientMeldingId} klientKorrelasjonsId {KlientKorrelasjonsid}", messageType, toAccountId, klientMeldingId, klientKorrelasjonsId);
             var sendtMessage = await _fiksIoClient
-                .Send(new MeldingRequest(_appSettings.FiksIOConfig.FiksIoAccountId, toAccountId, messageType, klientMeldingId: klientMeldingId), "testfile.txt")
+                .Send(new MeldingRequest(_appSettings.FiksIOConfig.FiksIoAccountId, toAccountId, messageType, klientMeldingId: klientMeldingId, klientKorrelasjonsId: klientKorrelasjonsId), "testfile.txt")
                 .ConfigureAwait(false);
             Log.Information("MessageSender - message sendt with messageid: {MessageId}", sendtMessage.MeldingId);
             return sendtMessage.MeldingId;

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientTests.cs
@@ -157,6 +157,7 @@ namespace KS.Fiks.IO.Client.Tests
             var expectedMessage = new SendtMelding(
                 meldingId: Guid.NewGuid(),
                 Guid.NewGuid(),
+                Guid.NewGuid().ToString(),
                 meldingType: "msgType",
                 avsenderKontoId: Guid.NewGuid(),
                 mottakerKontoId: Guid.NewGuid(),

--- a/KS.Fiks.IO.Client.Tests/Models/MeldingRequestTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Models/MeldingRequestTests.cs
@@ -8,7 +8,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
     public class MeldingRequestTests
     {
         [Fact]
-        public void FromMeldingRequestToApiModelNullKlientModelIdShouldBeEmptyHeadere()
+        public void FromMeldingRequestToApiModelShouldBeEmptyHeadere()
         {
             var result = new MeldingRequest(
                 Guid.NewGuid(),
@@ -18,7 +18,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
         }
 
         [Fact]
-        public void FromMeldingRequestToApiModelWithKlientModelIdShouldBeInHeadere()
+        public void FromMeldingRequestToApiModelWithKlientMeldingIdShouldBeInHeadere()
         {
             var klientMeldingId = Guid.NewGuid();
             var result = new MeldingRequest(
@@ -27,8 +27,22 @@ namespace KS.Fiks.IO.Client.Tests.Models
                 "meldingType",
                 klientMeldingId: klientMeldingId).ToApiModel();
             result.Headere.ShouldNotBeEmpty();
-            result.Headere.ContainsKey(MeldingBase.headerKlientMeldingId).ShouldBeTrue();
+            result.Headere.ContainsKey(MeldingBase.HeaderKlientMeldingId).ShouldBeTrue();
             result.Headere.ContainsValue(klientMeldingId.ToString()).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void FromMeldingRequestToApiModelWithKlientKorrelasjonsIdShouldBeInHeadere()
+        {
+            var klientKorrelasjonsId = Guid.NewGuid().ToString();
+            var result = new MeldingRequest(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                "meldingType",
+                klientKorrelasjonsId: klientKorrelasjonsId).ToApiModel();
+            result.Headere.ShouldNotBeEmpty();
+            result.Headere.ContainsKey(MeldingBase.HeaderKlientKorrelasjonsId).ShouldBeTrue();
+            result.Headere.ContainsValue(klientKorrelasjonsId).ShouldBeTrue();
         }
     }
 }

--- a/KS.Fiks.IO.Client.Tests/Models/MottattMeldingTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Models/MottattMeldingTests.cs
@@ -12,7 +12,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
         public void TestKlientMeldingIdIsExtractedFromHeaderWhenGuid()
         {
             var klientMeldingId = Guid.NewGuid();
-            var headere = new Dictionary<string, string>() {{ MeldingBase.headerKlientMeldingId, klientMeldingId.ToString() }};
+            var headere = new Dictionary<string, string>() {{ MeldingBase.HeaderKlientMeldingId, klientMeldingId.ToString() }};
             var mottattMelding = new MottattMelding(false,
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere), null, null, null);
@@ -24,7 +24,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
         public void TestKlientMeldingIdIsGuidEmptyWhenNotAGuid()
         {
             var klientMeldingId = "dette er ikke en guid";
-            var headere = new Dictionary<string, string>() {{ MeldingBase.headerKlientMeldingId, klientMeldingId }};
+            var headere = new Dictionary<string, string>() {{ MeldingBase.HeaderKlientMeldingId, klientMeldingId }};
             var mottattMelding = new MottattMelding(false,
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere), null, null, null);
@@ -47,7 +47,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
         public void TestResendtIsDefaultFalse()
         {
             var klientMeldingId = Guid.NewGuid();
-            var headere = new Dictionary<string, string>() {{ MeldingBase.headerKlientMeldingId, klientMeldingId.ToString() }};
+            var headere = new Dictionary<string, string>() {{ MeldingBase.HeaderKlientMeldingId, klientMeldingId.ToString() }};
             var mottattMelding = new MottattMelding(false,
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere), null, null, null);
@@ -60,7 +60,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
         {
             var resendt = true;
             var klientMeldingId = Guid.NewGuid();
-            var headere = new Dictionary<string, string>() {{ MeldingBase.headerKlientMeldingId, klientMeldingId.ToString() }};
+            var headere = new Dictionary<string, string>() {{ MeldingBase.HeaderKlientMeldingId, klientMeldingId.ToString() }};
             var mottattMelding = new MottattMelding(false,
                 new MottattMeldingMetadata(Guid.NewGuid(), "meldingtype", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, headere, resendt), null, null, null);

--- a/KS.Fiks.IO.Client.Tests/Models/SendtMeldingTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Models/SendtMeldingTests.cs
@@ -57,7 +57,7 @@ namespace KS.Fiks.IO.Client.Tests.Models
                     SvarPaMelding = Guid.NewGuid(),
                     AvsenderKontoId = Guid.NewGuid(),
                     DokumentlagerId = Guid.NewGuid(),
-                    Headere = new Dictionary<string, string>() {{ MeldingBase.headerKlientMeldingId, klientMeldingId.ToString() }},
+                    Headere = new Dictionary<string, string>() {{ MeldingBase.HeaderKlientMeldingId, klientMeldingId.ToString() }},
                     MeldingId = Guid.NewGuid(),
                     MeldingType = "EnMeldingType",
                     MottakerKontoId = Guid.NewGuid(),

--- a/KS.Fiks.IO.Client.Tests/Send/SendHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SendHandlerTests.cs
@@ -34,7 +34,7 @@ namespace KS.Fiks.IO.Client.Tests.Send
         }
 
         [Fact]
-        public async Task CallsSendWithExpectedMessageSpecificationApiModelWithKlientMeldingId()
+        public async Task CallsSendWithExpectedMessageSpecificationApiModelWithKlientHeaders()
         {
             var sut = _fixture.CreateSut();
 
@@ -42,6 +42,7 @@ namespace KS.Fiks.IO.Client.Tests.Send
                 avsenderKontoId: Guid.NewGuid(),
                 mottakerKontoId: Guid.NewGuid(),
                 klientMeldingId: Guid.NewGuid(),
+                klientKorrelasjonsId: Guid.NewGuid().ToString(),
                 meldingType: "Meldingsprotokoll",
                 ttl: TimeSpan.FromDays(2),
                 headere: null,
@@ -57,12 +58,13 @@ namespace KS.Fiks.IO.Client.Tests.Send
                              model.SvarPaMelding == request.SvarPaMelding &&
                              model.AvsenderKontoId == request.AvsenderKontoId &&
                              model.MottakerKontoId == request.MottakerKontoId &&
-                             model.Headere[MeldingBase.headerKlientMeldingId] == request.KlientMeldingId.ToString()),
+                             model.Headere[MeldingBase.HeaderKlientMeldingId] == request.KlientMeldingId.ToString() &&
+                             model.Headere[MeldingBase.HeaderKlientKorrelasjonsId] == request.KlientKorrelasjonsId),
                 It.IsAny<Stream>()));
         }
 
         [Fact]
-        public async Task CallsSendWithExpectedMessageSpecificationApiModelAndNullKlientMeldingId()
+        public async Task CallsSendWithExpectedMessageSpecificationApiModelAndNullKlientHeaders()
         {
             var sut = _fixture.CreateSut();
 
@@ -84,7 +86,8 @@ namespace KS.Fiks.IO.Client.Tests.Send
                              model.SvarPaMelding == request.SvarPaMelding &&
                              model.AvsenderKontoId == request.AvsenderKontoId &&
                              model.MottakerKontoId == request.MottakerKontoId &&
-                             !model.Headere.ContainsKey("klientMeldingId")),
+                             !model.Headere.ContainsKey("klientMeldingId") &&
+                             !model.Headere.ContainsKey("klientKorrelasjonsId")),
                 It.IsAny<Stream>()));
         }
 

--- a/KS.Fiks.IO.Client.Tests/Send/SvarSenderFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SvarSenderFixture.cs
@@ -69,7 +69,7 @@ namespace KS.Fiks.IO.Client.Tests.Send
         private void SetupMocks()
         {
             SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IPayload[]>()))
-                .ReturnsAsync(new SendtMelding(Guid.NewGuid(), Guid.NewGuid(), "sendtMelding", Guid.NewGuid(), Guid.NewGuid(),
+                .ReturnsAsync(new SendtMelding(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid().ToString(), "sendtMelding", Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, null));
         }
     }

--- a/KS.Fiks.IO.Client/Models/IMelding.cs
+++ b/KS.Fiks.IO.Client/Models/IMelding.cs
@@ -9,6 +9,8 @@ namespace KS.Fiks.IO.Client.Models
 
         Guid? KlientMeldingId { get; }
 
+        string KlientKorrelasjonsId { get;  }
+
         string MeldingType { get; }
 
         Guid AvsenderKontoId { get; }

--- a/KS.Fiks.IO.Client/Models/MeldingBase.cs
+++ b/KS.Fiks.IO.Client/Models/MeldingBase.cs
@@ -5,7 +5,8 @@ namespace KS.Fiks.IO.Client.Models
 {
     public abstract class MeldingBase : IMelding
     {
-        public const string headerKlientMeldingId = "klientMeldingId";
+        public const string HeaderKlientMeldingId = "klientMeldingId";
+        public const string HeaderKlientKorrelasjonsId = "klientKorrelasjonsId";
 
         protected MeldingBase()
         {
@@ -14,6 +15,7 @@ namespace KS.Fiks.IO.Client.Models
         protected MeldingBase(
             Guid meldingId,
             Guid? klientMeldingId,
+            string klientKorrelasjonsId,
             string meldingType,
             Guid avsenderKontoId,
             Guid mottakerKontoId,
@@ -24,6 +26,7 @@ namespace KS.Fiks.IO.Client.Models
         {
             MeldingId = meldingId;
             KlientMeldingId = klientMeldingId;
+            KlientKorrelasjonsId = klientKorrelasjonsId;
             MeldingType = meldingType;
             AvsenderKontoId = avsenderKontoId;
             MottakerKontoId = mottakerKontoId;
@@ -37,6 +40,7 @@ namespace KS.Fiks.IO.Client.Models
         {
             MeldingId = melding.MeldingId;
             KlientMeldingId = melding.KlientMeldingId;
+            KlientKorrelasjonsId = melding.KlientKorrelasjonsId;
             MeldingType = melding.MeldingType;
             AvsenderKontoId = melding.AvsenderKontoId;
             MottakerKontoId = melding.MottakerKontoId;
@@ -48,6 +52,8 @@ namespace KS.Fiks.IO.Client.Models
         public Guid MeldingId { get; protected set; }
 
         public Guid? KlientMeldingId { get; protected set; }
+
+        public string KlientKorrelasjonsId { get; protected set; }
 
         public string MeldingType { get; protected set; }
 

--- a/KS.Fiks.IO.Client/Models/MeldingRequest.cs
+++ b/KS.Fiks.IO.Client/Models/MeldingRequest.cs
@@ -15,24 +15,31 @@ namespace KS.Fiks.IO.Client.Models
             TimeSpan? ttl = null,
             Dictionary<string, string> headere = null,
             Guid? svarPaMelding = null,
-            Guid? klientMeldingId = null)
-        : base(
-            meldingId: Guid.Empty,
-            meldingType: meldingType,
-            klientMeldingId: klientMeldingId,
-            avsenderKontoId: avsenderKontoId,
-            mottakerKontoId: mottakerKontoId,
-            ttl: ttl ?? TimeSpan.FromDays(DefaultTtlInDays),
-            headere: headere ?? new Dictionary<string, string>(),
-            svarPaMelding: svarPaMelding)
-        {
+            Guid? klientMeldingId = null,
+            string klientKorrelasjonsId = null)
+            : base(
+                meldingId: Guid.Empty,
+                meldingType: meldingType,
+                klientMeldingId: klientMeldingId,
+                klientKorrelasjonsId: klientKorrelasjonsId,
+                avsenderKontoId: avsenderKontoId,
+                mottakerKontoId: mottakerKontoId,
+                ttl: ttl ?? TimeSpan.FromDays(DefaultTtlInDays),
+                headere: headere ?? new Dictionary<string, string>(),
+                svarPaMelding: svarPaMelding)
+                {
         }
 
         public MeldingSpesifikasjonApiModel ToApiModel()
         {
             if (KlientMeldingId != null && KlientMeldingId != Guid.Empty)
             {
-                Headere.Add(headerKlientMeldingId, KlientMeldingId.ToString());
+                Headere.Add(HeaderKlientMeldingId, KlientMeldingId.ToString());
+            }
+
+            if (!string.IsNullOrEmpty(KlientKorrelasjonsId))
+            {
+                Headere.Add(HeaderKlientKorrelasjonsId, KlientKorrelasjonsId);
             }
 
             return new MeldingSpesifikasjonApiModel(

--- a/KS.Fiks.IO.Client/Models/MottattMelding.cs
+++ b/KS.Fiks.IO.Client/Models/MottattMelding.cs
@@ -29,22 +29,33 @@ namespace KS.Fiks.IO.Client.Models
             _decrypter = decrypter;
             _fileWriter = fileWriter;
             KlientMeldingId = ExtractKlientMeldingId();
+            KlientKorrelasjonsId = ExtractKlientKorrelasjonsId();
         }
 
         private Guid? ExtractKlientMeldingId()
         {
-            if (Headere == null || !Headere.ContainsKey(headerKlientMeldingId))
+            if (Headere == null || !Headere.ContainsKey(HeaderKlientMeldingId))
             {
                 return null;
             }
 
             var parsed = Guid.Empty;
-            if (Guid.TryParse(Headere[headerKlientMeldingId], out parsed))
+            if (Guid.TryParse(Headere[HeaderKlientMeldingId], out parsed))
             {
                 return parsed;
             }
 
             return parsed;
+        }
+
+        private string ExtractKlientKorrelasjonsId()
+        {
+            if (Headere == null || !Headere.ContainsKey(HeaderKlientKorrelasjonsId))
+            {
+                return null;
+            }
+
+            return Headere[HeaderKlientKorrelasjonsId];
         }
 
         public bool HasPayload { get; }

--- a/KS.Fiks.IO.Client/Models/SendtMelding.cs
+++ b/KS.Fiks.IO.Client/Models/SendtMelding.cs
@@ -9,11 +9,11 @@ namespace KS.Fiks.IO.Client.Models
         public static SendtMelding FromSentMessageApiModel(SendtMeldingApiModel sendtMeldingApiModel)
         {
             Guid? klientMeldingId = null;
-            if (sendtMeldingApiModel.Headere != null && sendtMeldingApiModel.Headere.ContainsKey(headerKlientMeldingId))
+            if (sendtMeldingApiModel.Headere != null && sendtMeldingApiModel.Headere.TryGetValue(HeaderKlientMeldingId, out var klientMeldingIdValue))
             {
                 try
                 {
-                    klientMeldingId = Guid.Parse(sendtMeldingApiModel.Headere[headerKlientMeldingId]);
+                    klientMeldingId = Guid.Parse(klientMeldingIdValue);
                 }
                 catch (Exception e)
                 {
@@ -21,9 +21,16 @@ namespace KS.Fiks.IO.Client.Models
                 }
             }
 
+            string klientKorrelasjonsId = null;
+            if (sendtMeldingApiModel.Headere != null && sendtMeldingApiModel.Headere.TryGetValue(HeaderKlientKorrelasjonsId, out var klientKorrelasjonsIdValue))
+            {
+                klientKorrelasjonsId = klientKorrelasjonsIdValue;
+            }
+
             return new SendtMelding(
                 sendtMeldingApiModel.MeldingId,
                 klientMeldingId,
+                klientKorrelasjonsId,
                 sendtMeldingApiModel.MeldingType,
                 sendtMeldingApiModel.AvsenderKontoId,
                 sendtMeldingApiModel.MottakerKontoId,
@@ -35,13 +42,14 @@ namespace KS.Fiks.IO.Client.Models
         internal SendtMelding(
             Guid meldingId,
             Guid? klientMeldingId,
+            string klientKorrelasjonsId,
             string meldingType,
             Guid avsenderKontoId,
             Guid mottakerKontoId,
             TimeSpan ttl,
             Dictionary<string, string> headere,
             Guid? svarPaMelding=null)
-            : base(meldingId, klientMeldingId, meldingType, avsenderKontoId, mottakerKontoId, ttl, svarPaMelding: svarPaMelding)
+            : base(meldingId, klientMeldingId, klientKorrelasjonsId, meldingType, avsenderKontoId, mottakerKontoId, ttl, svarPaMelding: svarPaMelding)
         {
         }
     }

--- a/KS.Fiks.IO.Client/Send/SvarSender.cs
+++ b/KS.Fiks.IO.Client/Send/SvarSender.cs
@@ -78,6 +78,7 @@ namespace KS.Fiks.IO.Client.Send
                 avsenderKontoId: _mottattMelding.MottakerKontoId,
                 mottakerKontoId: _mottattMelding.AvsenderKontoId,
                 klientMeldingId: klientMeldingId,
+                klientKorrelasjonsId: _mottattMelding.KlientKorrelasjonsId,
                 meldingType: messageType,
                 ttl: null,
                 headere: null,

--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ The example project starts a console program that listens and subscribes to mess
 It listens to the Enter key in the console, that then triggers it to send a 'ping' message to your Fiks-IO account.
 When the program receives the 'ping' message it will reply to that message with a 'pong' message. 
 
-The program also adds the optional 'klientMeldingId' when sending messages and utilizes the IsOpen() feature to show the connection-status.
+The program also shows the following features:
+- It uses the optional `klientMeldingId` when sending messages 
+- It uses the optional `klientKorrelasjonsId` when sending messages, and shows that it is returned in the response from the receiver of the first message 
+- It utilizes the `IsOpen()` feature to show the connection-status.
+
+
 
 Read more in the [README.md](ExampleApplication/README.md) file for the example application.
 


### PR DESCRIPTION
Den nye headeren klientKorrelasjonsId er for at man skal kunne legge til en id når man sender en melding, som da vil bli kopiert inn i svaret man får tilbake. 
Denne id'en skal da følge dialogen fram og tilbake og når man bruker .Svar funksjonaliteten.