### PR TITLE
Add `CancellationToken support`

### DIFF
--- a/ExampleApplication/FiksIO/MessageSender.cs
+++ b/ExampleApplication/FiksIO/MessageSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client;
 using KS.Fiks.IO.Client.Models;
@@ -21,14 +22,14 @@ public class MessageSender
         _appSettings = appSettings;
     }
 
-    public async Task<Guid> Send(string messageType, Guid toAccountId)
+    public async Task<Guid> Send(string messageType, Guid toAccountId, CancellationToken cancellationToken = default)
     {
         try
         {
             var klientMeldingId = Guid.NewGuid();
             Log.Information("MessageSender - sending messagetype {MessageType} to account id: {AccountId} with klientMeldingId {KlientMeldingId}", messageType, toAccountId, klientMeldingId);
             var sendtMessage = await _fiksIoClient
-                .Send(new MeldingRequest(_appSettings.FiksIOConfig.FiksIoAccountId, toAccountId, messageType, klientMeldingId: klientMeldingId), "testfile.txt")
+                .Send(new MeldingRequest(_appSettings.FiksIOConfig.FiksIoAccountId, toAccountId, messageType, klientMeldingId: klientMeldingId), "testfile.txt", cancellationToken)
                 .ConfigureAwait(false);
             Log.Information("MessageSender - message sendt with messageid: {MessageId}", sendtMessage.MeldingId);
             return sendtMessage.MeldingId;

--- a/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/FiksIOClientFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Amqp;
 using KS.Fiks.IO.Client.Configuration;
@@ -153,8 +154,10 @@ namespace KS.Fiks.IO.Client.Tests
         private void SetupMocks()
         {
             CatalogHandlerMock.Setup(_ => _.Lookup(It.IsAny<LookupRequest>())).ReturnsAsync(_lookupReturn);
-            SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IList<IPayload>>()))
+            SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IList<IPayload>>(), It.IsAny<CancellationToken>()))
                            .ReturnsAsync(_sendtMeldingReturn);
+            SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IList<IPayload>>(), It.Is<CancellationToken>(x => x.IsCancellationRequested)))
+                .ThrowsAsync(new TaskCanceledException());
             AmqpHandlerMock.Setup(_ => _.AddMessageReceivedHandlerAsync(
                     It.IsAny<Func<MottattMeldingArgs, Task>>(),
                     It.IsAny<Func<ConsumerEventArgs, Task>>()))

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -9,23 +9,19 @@
         <OutputType>Library</OutputType>
         <LangVersion>latest</LangVersion>
         <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup>
         <CodeAnalysisRuleSet>..\fiks.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.2" />
-        <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
-        <PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
-        <PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />

--- a/KS.Fiks.IO.Client.Tests/Send/SendHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SendHandlerFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Client.Send;
 using KS.Fiks.IO.Crypto.Asic;
@@ -62,7 +63,8 @@ namespace KS.Fiks.IO.Client.Tests.Send
         {
             FiksIOSenderMock.Setup(_ => _.Send(
                                 It.IsAny<MeldingSpesifikasjonApiModel>(),
-                                It.IsAny<Stream>()))
+                                It.IsAny<Stream>(),
+                                It.IsAny<CancellationToken>()))
                             .ReturnsAsync(new SendtMeldingApiModel());
 
             AsicEncrypterMock.Setup(_ => _.Encrypt(It.IsAny<X509Certificate>(), It.IsAny<IList<IPayload>>()))

--- a/KS.Fiks.IO.Client.Tests/Send/SendHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SendHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Crypto.Models;
@@ -30,7 +31,12 @@ namespace KS.Fiks.IO.Client.Tests.Send
 
             await sut.Send(request, payload).ConfigureAwait(false);
 
-            _fixture.FiksIOSenderMock.Verify(_ => _.Send(It.IsAny<MeldingSpesifikasjonApiModel>(), It.IsAny<Stream>()));
+            _fixture.FiksIOSenderMock.Verify(
+                _ => _.Send(
+                    It.IsAny<MeldingSpesifikasjonApiModel>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -51,14 +57,17 @@ namespace KS.Fiks.IO.Client.Tests.Send
 
             await sut.Send(request, payload).ConfigureAwait(false);
 
-            _fixture.FiksIOSenderMock.Verify(_ => _.Send(
+            _fixture.FiksIOSenderMock.Verify(
+                _ => _.Send(
                 It.Is<MeldingSpesifikasjonApiModel>(
                     model => model.Ttl == (long)request.Ttl.TotalMilliseconds &&
                              model.SvarPaMelding == request.SvarPaMelding &&
                              model.AvsenderKontoId == request.AvsenderKontoId &&
                              model.MottakerKontoId == request.MottakerKontoId &&
                              model.Headere[MeldingBase.headerKlientMeldingId] == request.KlientMeldingId.ToString()),
-                It.IsAny<Stream>()));
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -78,14 +87,17 @@ namespace KS.Fiks.IO.Client.Tests.Send
 
             await sut.Send(request, payload).ConfigureAwait(false);
 
-            _fixture.FiksIOSenderMock.Verify(_ => _.Send(
+            _fixture.FiksIOSenderMock.Verify(
+                _ => _.Send(
                 It.Is<MeldingSpesifikasjonApiModel>(
                     model => model.Ttl == (long)request.Ttl.TotalMilliseconds &&
                              model.SvarPaMelding == request.SvarPaMelding &&
                              model.AvsenderKontoId == request.AvsenderKontoId &&
                              model.MottakerKontoId == request.MottakerKontoId &&
                              !model.Headere.ContainsKey("klientMeldingId")),
-                It.IsAny<Stream>()));
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]

--- a/KS.Fiks.IO.Client.Tests/Send/SvarSenderFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SvarSenderFixture.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Amqp;
 using KS.Fiks.IO.Client.FileIO;
@@ -68,9 +70,11 @@ namespace KS.Fiks.IO.Client.Tests.Send
 
         private void SetupMocks()
         {
-            SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IPayload[]>()))
+            SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IPayload[]>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new SendtMelding(Guid.NewGuid(), Guid.NewGuid(), "sendtMelding", Guid.NewGuid(), Guid.NewGuid(),
                     TimeSpan.Zero, null));
+            SendHandlerMock.Setup(_ => _.Send(It.IsAny<MeldingRequest>(), It.IsAny<IList<IPayload>>(), It.Is<CancellationToken>(x => x.IsCancellationRequested)))
+                .ThrowsAsync(new TaskCanceledException());
         }
     }
 }

--- a/KS.Fiks.IO.Client/IFiksIOClient.cs
+++ b/KS.Fiks.IO.Client/IFiksIOClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Crypto.Models;
@@ -19,15 +20,15 @@ namespace KS.Fiks.IO.Client
 
         Task<Status> GetKontoStatus(Guid kontoId);
 
-        Task<SendtMelding> Send(MeldingRequest request);
+        Task<SendtMelding> Send(MeldingRequest request, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Send(MeldingRequest request, IList<IPayload> payload);
+        Task<SendtMelding> Send(MeldingRequest request, IList<IPayload> payload, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Send(MeldingRequest request, string pathToPayload);
+        Task<SendtMelding> Send(MeldingRequest request, string pathToPayload, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Send(MeldingRequest request, string payload, string filename);
+        Task<SendtMelding> Send(MeldingRequest request, string payload, string filename, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Send(MeldingRequest request, Stream payload, string filename);
+        Task<SendtMelding> Send(MeldingRequest request, Stream payload, string filename, CancellationToken cancellationToken = default);
 
         Task NewSubscriptionAsync(Func<MottattMeldingArgs, Task> onMottattMelding, Func<ConsumerEventArgs, Task> onCanceled = null);
 

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -42,8 +42,8 @@
 		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.2" />
-		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
+		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.4" />
+		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="2.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
 		<PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/KS.Fiks.IO.Client/Send/ISendHandler.cs
+++ b/KS.Fiks.IO.Client/Send/ISendHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Crypto.Models;
@@ -7,6 +8,6 @@ namespace KS.Fiks.IO.Client.Send
 {
     public interface ISendHandler
     {
-        Task<SendtMelding> Send(MeldingRequest request, IList<IPayload> payload);
+        Task<SendtMelding> Send(MeldingRequest request, IList<IPayload> payload, CancellationToken cancellationToken = default);
     }
 }

--- a/KS.Fiks.IO.Client/Send/ISvarSender.cs
+++ b/KS.Fiks.IO.Client/Send/ISvarSender.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Crypto.Models;
@@ -9,15 +10,15 @@ namespace KS.Fiks.IO.Client.Send
 {
     public interface ISvarSender
     {
-        Task<SendtMelding> Svar(string meldingType, IList<IPayload> payloads, Guid? klientMeldingId = default);
+        Task<SendtMelding> Svar(string meldingType, IList<IPayload> payloads, Guid? klientMeldingId = default, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Svar(string meldingType, Stream melding, string filnavn, Guid? klientMeldingId = default);
+        Task<SendtMelding> Svar(string meldingType, Stream melding, string filnavn, Guid? klientMeldingId = default, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Svar(string meldingType, string melding, string filnavn, Guid? klientMeldingId = default);
+        Task<SendtMelding> Svar(string meldingType, string melding, string filnavn, Guid? klientMeldingId = default, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Svar(string meldingType, string filLokasjon, Guid? klientMeldingId = default);
+        Task<SendtMelding> Svar(string meldingType, string filLokasjon, Guid? klientMeldingId = default, CancellationToken cancellationToken = default);
 
-        Task<SendtMelding> Svar(string meldingType, Guid? klientMeldingId = default);
+        Task<SendtMelding> Svar(string meldingType, Guid? klientMeldingId = default, CancellationToken cancellationToken = default);
 
         /**
         * Acknowledges that the message has been consumed

--- a/KS.Fiks.IO.Client/Send/SendHandler.cs
+++ b/KS.Fiks.IO.Client/Send/SendHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Crypto.Asic;
@@ -47,10 +48,10 @@ namespace KS.Fiks.IO.Client.Send
         {
         }
 
-        public async Task<SendtMelding> Send(MeldingRequest request, IList<IPayload> payload)
+        public async Task<SendtMelding> Send(MeldingRequest request, IList<IPayload> payload, CancellationToken cancellationToken = default)
         {
             var encryptedPayload = await GetEncryptedPayload(request, payload).ConfigureAwait(false);
-            var sentMessageApiModel = await _sender.Send(request.ToApiModel(), encryptedPayload)
+            var sentMessageApiModel = await _sender.Send(request.ToApiModel(), encryptedPayload, cancellationToken)
                                                    .ConfigureAwait(false);
 
             return SendtMelding.FromSentMessageApiModel(sentMessageApiModel);

--- a/KS.Fiks.IO.Client/Send/SvarSender.cs
+++ b/KS.Fiks.IO.Client/Send/SvarSender.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Client.Amqp;
 using KS.Fiks.IO.Client.Models;
@@ -23,32 +24,32 @@ namespace KS.Fiks.IO.Client.Send
             _amqpAcknowledgeManager = amqpAcknowledgeManager;
         }
 
-        public async Task<SendtMelding> Svar(string meldingType, IList<IPayload> payloads, Guid? klientMeldingId = default)
+        public async Task<SendtMelding> Svar(string meldingType, IList<IPayload> payloads, Guid? klientMeldingId = default, CancellationToken cancellationToken = default)
         {
-            return await _sendHandler.Send(CreateMessageRequest(meldingType, klientMeldingId), payloads).ConfigureAwait(false);
+            return await _sendHandler.Send(CreateMessageRequest(meldingType, klientMeldingId), payloads, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<SendtMelding> Svar(string meldingType, Stream melding, string filnavn, Guid? klientMeldingId = default)
+        public async Task<SendtMelding> Svar(string meldingType, Stream melding, string filnavn, Guid? klientMeldingId = default, CancellationToken cancellationToken = default)
         {
-            return await Reply(meldingType, new StreamPayload(melding, filnavn), klientMeldingId)
+            return await Reply(meldingType, new StreamPayload(melding, filnavn), klientMeldingId, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        public async Task<SendtMelding> Svar(string meldingType, string melding, string filnavn, Guid? klientMeldingId = default)
+        public async Task<SendtMelding> Svar(string meldingType, string melding, string filnavn, Guid? klientMeldingId = default, CancellationToken cancellationToken = default)
         {
-            return await Reply(meldingType, new StringPayload(melding, filnavn), klientMeldingId)
+            return await Reply(meldingType, new StringPayload(melding, filnavn), klientMeldingId, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        public async Task<SendtMelding> Svar(string meldingType, string filLokasjon, Guid? klientMeldingId = default)
+        public async Task<SendtMelding> Svar(string meldingType, string filLokasjon, Guid? klientMeldingId = default, CancellationToken cancellationToken = default)
         {
-            return await Reply(meldingType, new FilePayload(filLokasjon), klientMeldingId)
+            return await Reply(meldingType, new FilePayload(filLokasjon), klientMeldingId, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        public async Task<SendtMelding> Svar(string meldingType, Guid? klientMeldingId = default)
+        public async Task<SendtMelding> Svar(string meldingType, Guid? klientMeldingId = default, CancellationToken cancellationToken = default)
         {
-            return await Svar(meldingType, new List<IPayload>(), klientMeldingId)
+            return await Svar(meldingType, new List<IPayload>(), klientMeldingId, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -67,7 +68,7 @@ namespace KS.Fiks.IO.Client.Send
             await _amqpAcknowledgeManager.NackWithRequeueAsync().ConfigureAwait(false);
         }
 
-        private async Task<SendtMelding> Reply(string messageType, IPayload payload, Guid? klientMeldingId)
+        private async Task<SendtMelding> Reply(string messageType, IPayload payload, Guid? klientMeldingId, CancellationToken cancellationToken)
         {
             return await Svar(messageType, new List<IPayload> {payload}, klientMeldingId).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Description
This PR updates the `FiksIOSender` client and implements the new support for cancellation tokens.

## Related issues
- https://github.com/ks-no/fiks-io-send-client-dotnet/pull/127