### PR TITLE
Støtte for .netstandard 2.0 og bumping av deps

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />

--- a/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
+++ b/KS.Fiks.IO.Client.Tests/KS.Fiks.IO.Client.Tests.csproj
@@ -15,14 +15,14 @@
         <CodeAnalysisRuleSet>..\fiks.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>

--- a/KS.Fiks.IO.Client/Amqp/AmqpConnectionManager.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpConnectionManager.cs
@@ -12,7 +12,7 @@ namespace KS.Fiks.IO.Client.Amqp
     public class AmqpConnectionManager
     {
         private readonly IConnectionFactory _connectionFactory;
-        private readonly SslOption? _sslOption;
+        private readonly SslOption _sslOption;
         private readonly SemaphoreSlim _tokenBucket;
         private readonly int _bucketSize;
         private readonly TimeSpan _tokenFillRate;

--- a/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpHandler.cs
@@ -89,7 +89,10 @@ namespace KS.Fiks.IO.Client.Amqp
             _receivedEvent = receivedEvent;
             _cancelledEvent = cancelledEvent;
 
-            _receiveConsumer ??= _amqpConsumerFactory.CreateReceiveConsumer(_channel);
+            if (_receiveConsumer == null)
+            {
+                _receiveConsumer = _amqpConsumerFactory.CreateReceiveConsumer(_channel);
+            }
 
             _receiveConsumer.ReceivedAsync += receivedEvent;
             _receiveConsumer.ConsumerCancelledAsync += cancelledEvent;
@@ -103,7 +106,7 @@ namespace KS.Fiks.IO.Client.Amqp
 
         public Task<bool> IsOpenAsync()
         {
-            return Task.FromResult(_channel is { IsOpen: true } && _connection is { IsOpen: true });
+            return Task.FromResult(_channel?.IsOpen == true && _connection?.IsOpen == true);
         }
 
         public async ValueTask DisposeAsync()

--- a/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpReceiveConsumer.cs
@@ -101,7 +101,7 @@ namespace KS.Fiks.IO.Client.Amqp
 
         private async Task AcknowledgeMessageAsync(ulong deliveryTag, CancellationToken cancellationToken)
         {
-            if (Channel is { IsOpen: true })
+            if (Channel?.IsOpen == true)
             {
                 await Channel.BasicAckAsync(deliveryTag, false, cancellationToken).ConfigureAwait(false);
             }
@@ -109,7 +109,7 @@ namespace KS.Fiks.IO.Client.Amqp
 
         private async Task RejectMessageAsync(ulong deliveryTag, bool requeue, CancellationToken cancellationToken)
         {
-            if (Channel is { IsOpen: true })
+            if (Channel?.IsOpen == true)
             {
                 await Channel.BasicNackAsync(deliveryTag, false, requeue, cancellationToken).ConfigureAwait(false);
             }

--- a/KS.Fiks.IO.Client/FiksIOClient.cs
+++ b/KS.Fiks.IO.Client/FiksIOClient.cs
@@ -75,10 +75,13 @@ namespace KS.Fiks.IO.Client
                 _maskinportenClient,
                 httpClient);
 
-            asicEncrypter ??= new AsicEncrypter(
-                new AsiceBuilderFactory(),
-                new EncryptionServiceFactory(),
-                AsicSigningCertificateHolderFactory.Create(configuration.AsiceSigningConfiguration));
+            if (asicEncrypter == null)
+            {
+                asicEncrypter = new AsicEncrypter(
+                    new AsiceBuilderFactory(),
+                    new EncryptionServiceFactory(),
+                    AsicSigningCertificateHolderFactory.Create(configuration.AsiceSigningConfiguration));
+            }
 
             _sendHandler = sendHandler ??
                            new SendHandler(
@@ -136,16 +139,19 @@ namespace KS.Fiks.IO.Client
             FiksIOConfiguration configuration,
             IAmqpWatcher amqpWatcher = null)
         {
-            _amqpHandler ??= await AmqpHandler.CreateAsync(
-                _maskinportenClient,
-                _sendHandler,
-                _dokumentlagerHandler,
-                configuration.AmqpConfiguration,
-                configuration.IntegrasjonConfiguration,
-                configuration.KontoConfiguration,
-                _loggerFactory,
-                connectionFactory: null,
-                amqpWatcher: amqpWatcher).ConfigureAwait(false);
+            if (_amqpHandler == null)
+            {
+                _amqpHandler = await AmqpHandler.CreateAsync(
+                    _maskinportenClient,
+                    _sendHandler,
+                    _dokumentlagerHandler,
+                    configuration.AmqpConfiguration,
+                    configuration.IntegrasjonConfiguration,
+                    configuration.KontoConfiguration,
+                    _loggerFactory,
+                    connectionFactory: null,
+                    amqpWatcher: amqpWatcher).ConfigureAwait(false);
+            }
         }
 
         public Guid KontoId { get; }

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -45,11 +45,11 @@
 		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.4" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="2.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-		<PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
+		<PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RabbitMQ.Client.OAuth2" Version="1.0.0" />
-		<PackageReference Include="System.Text.Json" Version="9.0.1" />
+		<PackageReference Include="System.Text.Json" Version="9.0.3" />
 	</ItemGroup>
 </Project>

--- a/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
+++ b/KS.Fiks.IO.Client/KS.Fiks.IO.Client.csproj
@@ -13,7 +13,7 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>FIKS</PackageTags>
 		<VersionPrefix>6.0.1</VersionPrefix>
-		<TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<AssemblyVersion>5.0.0.0</AssemblyVersion>
@@ -42,7 +42,7 @@
 		<None Remove="Schema\no.ks.fiks.kvittering.serverfeil.v1.schema.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.4" />
+		<PackageReference Include="KS.Fiks.IO.Send.Client" Version="2.0.5" />
 		<PackageReference Include="KS.Fiks.Maskinporten.Client" Version="2.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
 		<PackageReference Include="RabbitMQ.Client" Version="7.1.2" />

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 
 ## About this library
-This is a .NET library compatible with _[.Net Standard 2.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)_ for sending and receiving messages using [Fiks IO](//ks-no.github.io/fiks-platform/tjenester/fiksio/).
+This is a .NET library compatible with _[.Net Standard 2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1)_ and _[.Net Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0)_ for sending and receiving messages using [Fiks IO](//ks-no.github.io/fiks-platform/tjenester/fiksio/).
 
 Fiks IO is a messaging system for the public sector in Norway. [About Fiks IO (Norwegian)](https://ks-no.github.io/fiks-plattform/tjenester/fiksprotokoll/fiksio/)
 


### PR DESCRIPTION
**Hvorfor er dette gjort?**
Vi er nødt til å støtte netstandard 2.0. 

**Hva er gjort:**
La inn støtte for netstandard 2.0. Oppdatert noe kode til å følge netstandard 2.0 (C# 7.3). Readme er også oppdatert.
Bumpet deps.