### PR TITLE
Kaster exception hvis man setter parameter og header med ulike verdier

### DIFF
--- a/KS.Fiks.IO.Client.Tests/Send/SendHandlerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SendHandlerTests.cs
@@ -21,7 +21,7 @@ namespace KS.Fiks.IO.Client.Tests.Send
         }
 
         [Fact]
-        public async Task CallsFiksIOSenderSend()
+        public async Task Verify_Send_Message()
         {
             var sut = _fixture.CreateSut();
 
@@ -40,7 +40,7 @@ namespace KS.Fiks.IO.Client.Tests.Send
         }
 
         [Fact]
-        public async Task CallsSendWithExpectedMessageSpecificationApiModelWithKlientHeaders()
+        public async Task Verify_MessageSpecification_On_Send_With_ApiModel_With_KlientHeaders()
         {
             var sut = _fixture.CreateSut();
 
@@ -73,7 +73,83 @@ namespace KS.Fiks.IO.Client.Tests.Send
         }
 
         [Fact]
-        public async Task CallsSendWithExpectedMessageSpecificationApiModelAndNullKlientHeaders()
+        public async Task Verify_MessageSpecification_On_Send_With_ApiModel_With_To_Equal_KlientHeaders()
+        {
+            var sut = _fixture.CreateSut();
+            var klientKorrelasjonsId = Guid.NewGuid().ToString();
+            var klientMeldingId = Guid.NewGuid();
+
+            var request = new MeldingRequest(
+                avsenderKontoId: Guid.NewGuid(),
+                mottakerKontoId: Guid.NewGuid(),
+                klientMeldingId: klientMeldingId,
+                klientKorrelasjonsId: klientKorrelasjonsId,
+                meldingType: "Meldingsprotokoll",
+                ttl: TimeSpan.FromDays(2),
+                headere: new Dictionary<string, string>() {{MeldingBase.HeaderKlientKorrelasjonsId, klientKorrelasjonsId}, {MeldingBase.HeaderKlientMeldingId, klientMeldingId.ToString() }},
+                svarPaMelding: Guid.NewGuid());
+
+            var payload = new List<IPayload>();
+
+            await sut.Send(request, payload).ConfigureAwait(false);
+
+            _fixture.FiksIOSenderMock.Verify(
+                _ => _.Send(
+                    It.Is<MeldingSpesifikasjonApiModel>(
+                        model => model.Ttl == (long)request.Ttl.TotalMilliseconds &&
+                                 model.SvarPaMelding == request.SvarPaMelding &&
+                                 model.AvsenderKontoId == request.AvsenderKontoId &&
+                                 model.MottakerKontoId == request.MottakerKontoId &&
+                                 model.Headere[MeldingBase.HeaderKlientMeldingId] == request.KlientMeldingId.ToString() &&
+                                 model.Headere[MeldingBase.HeaderKlientKorrelasjonsId] == request.KlientKorrelasjonsId),
+                    It.IsAny<Stream>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Verify_Exception_Returned_When_Send_With_Two_Different_KlientKorrelasjonsId_Set()
+        {
+            var sut = _fixture.CreateSut();
+            var klientKorrelasjonsId1 = Guid.NewGuid().ToString();
+            var klientKorrelasjonsId2 = Guid.NewGuid().ToString();
+
+            var request = new MeldingRequest(
+                avsenderKontoId: Guid.NewGuid(),
+                mottakerKontoId: Guid.NewGuid(),
+                klientKorrelasjonsId: klientKorrelasjonsId1,
+                meldingType: "Meldingsprotokoll",
+                ttl: TimeSpan.FromDays(2),
+                headere: new Dictionary<string, string>() {{MeldingBase.HeaderKlientKorrelasjonsId, klientKorrelasjonsId2}},
+                svarPaMelding: Guid.NewGuid());
+
+            var payload = new List<IPayload>();
+            await Assert.ThrowsAsync<ArgumentException>(() => sut.Send(request, payload));
+        }
+
+        [Fact]
+        public async Task Verify_Exception_Returned_When_Send_With_Two_Different_KlientMeldingId_Set()
+        {
+            var sut = _fixture.CreateSut();
+            var klientMeldingId1 = Guid.NewGuid();
+            var klientMeldingId2 = Guid.NewGuid();
+
+            var request = new MeldingRequest(
+                avsenderKontoId: Guid.NewGuid(),
+                mottakerKontoId: Guid.NewGuid(),
+                klientMeldingId: klientMeldingId1,
+                meldingType: "Meldingsprotokoll",
+                ttl: TimeSpan.FromDays(2),
+                headere: new Dictionary<string, string>() {{MeldingBase.HeaderKlientMeldingId, klientMeldingId2.ToString()}},
+                svarPaMelding: Guid.NewGuid());
+
+            var payload = new List<IPayload>();
+            await Assert.ThrowsAsync<ArgumentException>(() => sut.Send(request, payload));
+        }
+
+
+        [Fact]
+        public async Task Verify_MessageSpecification_On_Send_With_ApiModel_With_Null_KlientHeaders()
         {
             var sut = _fixture.CreateSut();
 
@@ -104,7 +180,7 @@ namespace KS.Fiks.IO.Client.Tests.Send
         }
 
         [Fact]
-        public async Task CallsEncrypterWithExpectedPrivateKey()
+        public async Task Verify_Encrypter_With_Expected_PrivateKey()
         {
             var expectedPublicKey = _fixture.CreateTestCertificate();
             var sut = _fixture.WithPublicKey(expectedPublicKey).CreateSut();
@@ -117,7 +193,7 @@ namespace KS.Fiks.IO.Client.Tests.Send
         }
 
         [Fact]
-        public async Task GetsKeyFromCatalogHandler()
+        public async Task Verify_GetKey_From_CatalogHandler()
         {
             var sut = _fixture.CreateSut();
             var request = _fixture.DefaultRequest;

--- a/KS.Fiks.IO.Client.Tests/Send/SvarSenderTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Send/SvarSenderTests.cs
@@ -97,6 +97,25 @@ namespace KS.Fiks.IO.Client.Tests.Send
         }
 
         [Fact]
+        public async Task SendsToAvsenderWithKlientKorrelasjonsId_2()
+        {
+            var meldingId = Guid.NewGuid();
+            var mottakerKonto = Guid.NewGuid();
+            var avsenderKonto = Guid.NewGuid();
+            var klientKorrelasjonsId = Guid.NewGuid().ToString();
+
+            var headere = new Dictionary<string, string>() {{ MeldingBase.HeaderKlientKorrelasjonsId, klientKorrelasjonsId }};
+
+            var motattMelding = new MottattMelding(hasPayload: true, metadata: new MottattMeldingMetadata(meldingId, "testType", mottakerKonto, avsenderKonto, null, TimeSpan.FromDays(1), headere), streamProvider: _fixture.DefaultStreamProvider, decrypter: _fixture.DefaultDecrypter, fileWriter: _fixture.DefaultFileWriter);
+
+            var sut = _fixture.WithMottattMelding(motattMelding).CreateSut();
+
+            await sut.Svar("testType");
+
+            _fixture.SendHandlerMock.Verify(_ => _.Send(It.Is<MeldingRequest>(a => a.MottakerKontoId == avsenderKonto && a.AvsenderKontoId == mottakerKonto && a.KlientKorrelasjonsId == klientKorrelasjonsId), It.IsAny<IList<IPayload>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
         public async Task SendsToAvsenderWithMottakerAsAvsenderAndWithKlientMeldingId()
         {
             var melding = GetDefaultMottattMelding();

--- a/KS.Fiks.IO.Client/Models/MeldingRequest.cs
+++ b/KS.Fiks.IO.Client/Models/MeldingRequest.cs
@@ -34,12 +34,34 @@ namespace KS.Fiks.IO.Client.Models
         {
             if (KlientMeldingId != null && KlientMeldingId != Guid.Empty)
             {
-                Headere.Add(HeaderKlientMeldingId, KlientMeldingId.ToString());
+                if (Headere != null && Headere.TryGetValue(HeaderKlientMeldingId, out var headerValue))
+                {
+                    if (!KlientMeldingId.ToString().Equals(headerValue))
+                    {
+                        throw new ArgumentException(
+                            $"Header dictionary contains a KlientMeldingId that doesn't match the KlientMeldingId as set in parameter. KlientMeldingId in header: {headerValue} - KlientMeldingId in parameter: {KlientMeldingId}");
+                    }
+                }
+                else
+                {
+                    Headere.Add(HeaderKlientMeldingId, KlientMeldingId.ToString());
+                }
             }
 
             if (!string.IsNullOrEmpty(KlientKorrelasjonsId))
             {
-                Headere.Add(HeaderKlientKorrelasjonsId, KlientKorrelasjonsId);
+                if (Headere != null && Headere.TryGetValue(HeaderKlientKorrelasjonsId, out var headerValue))
+                {
+                    if (!KlientKorrelasjonsId.Equals(headerValue))
+                    {
+                        throw new ArgumentException(
+                            $"Header dictionary contains a KlientKorrelasjonsId that doesn't match the KlientKorrelasjonsId as set in parameter. KlientKorrelasjonsId in header: {headerValue} - KlientKorrelasjonsId in parameter: {KlientKorrelasjonsId}");
+                    }
+                }
+                else
+                {
+                    Headere.Add(HeaderKlientKorrelasjonsId, KlientKorrelasjonsId);
+                }
             }
 
             return new MeldingSpesifikasjonApiModel(


### PR DESCRIPTION
Det viser seg at det feiler hvis man forsøkte å sette `klientMeldingId` og/eller `klientKorrelasjonsId` både via header og som inn-parameter til metoden. Dette skjedde fordi koden vil sette header fra parameter og da eksisterer nøkkel i header fra før.

Nå tillater vi at man setter verdier for disse 2 både via header og parameter så lenge det er samme verdi.
Hvis man setter forskjellige verdier i header og parameter så kastes en `ArgumentException`