### PR TITLE
Fixes issues with connections to RabbitMQ failing due to failure to retrive maskinporten token

### DIFF
--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpConnectionManagerTests.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpConnectionManagerTests.cs
@@ -33,6 +33,10 @@ public class AmqpConnectionManagerTests
             .Setup(cf => cf.CreateConnectionAsync(It.IsAny<List<AmqpTcpEndpoint>>(), It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(connectionMock.Object);
+        
+        _connectionFactoryMock
+            .Setup(factory => factory.CredentialsProvider.GetCredentialsAsync(
+                It.IsAny<CancellationToken>())).ReturnsAsync(new Credentials("test", "test", "test", TimeSpan.FromMinutes(5)));
     }
 
     [Fact]

--- a/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
+++ b/KS.Fiks.IO.Client.Tests/Amqp/AmqpHandlerFixture.cs
@@ -124,6 +124,11 @@ namespace KS.Fiks.IO.Client.Tests.Amqp
                         It.IsAny<string>(),
                         It.IsAny<CancellationToken>()))
                     .ReturnsAsync(ConnectionMock.Object);
+
+                ConnectionFactoryMock
+                    .Setup(factory => factory.CredentialsProvider.GetCredentialsAsync(
+                        It.IsAny<CancellationToken>())).ReturnsAsync(new Credentials("test", "test", "test", TimeSpan.FromMinutes(5)));
+
             }
 
             ConnectionFactoryMock.SetupSet(connection => connection.Password = It.IsAny<string>());

--- a/KS.Fiks.IO.Client/Amqp/AmqpConnectionManager.cs
+++ b/KS.Fiks.IO.Client/Amqp/AmqpConnectionManager.cs
@@ -80,6 +80,8 @@ namespace KS.Fiks.IO.Client.Amqp
                 await _tokenBucket.WaitAsync().ConfigureAwait(false);
                 _logger?.LogDebug("Token acquired, proceeding to create connection");
 
+                CheckThatCredentialsCanBeRetrieved();
+
                 var endpoint = new AmqpTcpEndpoint(configuration.Host, configuration.Port, _sslOption);
                 var connection = await _connectionFactory
                     .CreateConnectionAsync(new List<AmqpTcpEndpoint> { endpoint }, configuration.ApplicationName)
@@ -91,6 +93,18 @@ namespace KS.Fiks.IO.Client.Amqp
             {
                 _logger?.LogError(ex, "Failed to create connection to {Host}:{Port}", configuration.Host, configuration.Port);
                 throw new FiksIOAmqpConnectionFailedException($"Failed to create connection to {configuration.Host}:{configuration.Port}", ex);
+            }
+        }
+
+        private void CheckThatCredentialsCanBeRetrieved()
+        {
+            if (_connectionFactory.CredentialsProvider != null)
+            {
+                _connectionFactory.CredentialsProvider.GetCredentialsAsync().Wait();
+            }
+            else
+            {
+                throw new FiksIOMaskinportenTokenException("CredentialProvider is not configured");
             }
         }
     }


### PR DESCRIPTION
Changing CreateConnectionAsync to check for the token before attempting connection.